### PR TITLE
Add shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+{}:
+let pkgs = (import ./. {}).obelisk.nixpkgs;
+in
+  pkgs.mkShell {
+    name = "hydra-pay";
+    buildInputs = [
+    ];
+    inputsFrom = [
+      (import ./. {}).shells.ghc
+    ];
+  }


### PR DESCRIPTION
`nix-shell` will now give you a shell where you have access to the executables used by the hydra-pay application including: ghc, cabal, cardano-cli, cardano-node, and so on.