### PR TITLE
Better live docs for unmanaged Cardano Network

### DIFF
--- a/backend/backend.cabal
+++ b/backend/backend.cabal
@@ -71,7 +71,7 @@ library
 
   exposed-modules:
     Backend
-    Config
+    ParseConfig
     HydraPay
     HydraPay.Server
     HydraPay.Network

--- a/backend/backend.cabal
+++ b/backend/backend.cabal
@@ -1,6 +1,6 @@
 name: backend
 version: 0.1
-cabal-version: >= 1.8
+cabal-version: >= 1.10
 build-type: Simple
 
 library

--- a/backend/src-bin/main.hs
+++ b/backend/src-bin/main.hs
@@ -2,7 +2,8 @@ import Backend
 import Frontend
 import Obelisk.Backend
 import Snap.Internal.Http.Server.Config
-import Config
+import ParseConfig
+import HydraPay.Config
 import Data.ByteString.UTF8 as BSU
 
 main :: IO ()

--- a/backend/src/Backend.hs
+++ b/backend/src/Backend.hs
@@ -17,7 +17,7 @@ import HydraPay.Logging
 import Obelisk.Backend
 import Obelisk.Route
 import Prelude hiding (filter)
-import Config
+import ParseConfig
 
 backend :: Backend BackendRoute FrontendRoute
 backend = Backend

--- a/backend/src/Config.hs
+++ b/backend/src/Config.hs
@@ -15,7 +15,7 @@ data HydraPayConfig = HydraPayConfig
 -- explicit configuration for Cardano Node and Hydra Nodes, or the
 -- default mode which runs a devnet for live documentation.
 data HydraPayMode
-  = LiveDocMode
+  = ManagedDevnetMode
   | ConfiguredMode
     { _cardanoNodeParams :: CardanoNodeParams
     , _hydraNodeParams :: HydraNodeParams
@@ -44,18 +44,18 @@ ignoreObeliskRunArgs p =
   (\_ a -> a) <$> switch (long "quiet" <> hidden) <*> p
 
 
--- | Unless specified otherwise the default is 'LiveDocMode'.
+-- | Unless specified otherwise the default is 'ManagedDevnet'.
 hydraPayConfigParser :: Parser HydraPayConfig
 hydraPayConfigParser =
   ignoreObeliskRunArgs
   $ HydraPayConfig
-  <$> (fromMaybe LiveDocMode <$> optional netConfigParser)
+  <$> (fromMaybe ManagedDevnetMode <$> optional netConfigParser)
   <*> (fromMaybe 8000 <$> optional (option auto (long "port" <> help "Port to use for the WebSocket endpoint and live documentation page")))
   <*> (fromMaybe "0.0.0.0" <$> optional (strOption (long "bind" <> help "Address or hostname to bind to")))
 
 netConfigParser :: Parser HydraPayMode
 netConfigParser =
-  flag' LiveDocMode (long "live-docs" <> help "Provide a live documentation page which runs HydraPay on a Cardano Devnet")
+  flag' ManagedDevnetMode (long "manage-devnet" <> help "Have Hydra Pay start a Cardano devnet. The socket and configuration can be found in the livedoc-devnet directory while it's running.")
   <|> (uncurry ConfiguredMode <$> nodeParamsParser)
 
 nodeParamsParser :: Parser (CardanoNodeParams, HydraNodeParams)

--- a/backend/src/Hydra/Devnet.hs
+++ b/backend/src/Hydra/Devnet.hs
@@ -42,6 +42,7 @@ module Hydra.Devnet
   , getDevnetAddresses
   , devnetFaucetKeys
   , cardanoDevnetNodeInfo
+  , writeProtocolParameters
   )
 
 where
@@ -271,6 +272,17 @@ waitForTxIn cninf txin = do
 
 cardanoNodeArgs :: CardanoNodeInfo -> [String]
 cardanoNodeArgs cninf = ["--testnet-magic", show . _testNetMagic . _nodeType $ cninf]
+
+writeProtocolParameters :: CardanoNodeInfo ->  IO ()
+writeProtocolParameters cninf = do
+  void $ readCreateProcess ((proc cardanoCliPath ([ "query"
+                                    , "protocol-parameters"
+                                    , "--out-file"
+                                    , _nodeLedgerProtocolParameters cninf
+                                    ]
+                       <> cardanoNodeArgs cninf))
+            { env = Just [( "CARDANO_NODE_SOCKET_PATH" , _nodeSocket cninf)]
+            }) ""
 
 txInExists :: CardanoNodeInfo -> TxIn -> IO Bool
 txInExists cninf txin = do

--- a/backend/src/HydraPay/Server.hs
+++ b/backend/src/HydraPay/Server.hs
@@ -153,7 +153,7 @@ newtype Network = Network
 runningDevnet :: MonadIO m => State -> m Bool
 runningDevnet state = do
   pure $ case getHydraPayMode state of
-    LiveDocMode -> True
+    ManagedDevnetMode -> True
     _ -> False
 
 runHydraPay :: HydraPayConfig -> (State -> IO a) -> IO a
@@ -201,7 +201,7 @@ runHydraPay cfg action = do
 -- | If we're in 'LiveDocMode' delete the devnet and restart it.
 makeCardanoNodeStateAndRestartDemoDevnet :: (MonadIO m) => HydraPayMode -> m (Either String CardanoNodeState)
 makeCardanoNodeStateAndRestartDemoDevnet = \case
-  LiveDocMode -> liftIO $ runExceptT $ do
+  ManagedDevnetMode -> liftIO $ runExceptT $ do
       lift $ do
         removePathForcibly "devnet"
         removePathForcibly nodeLogDir
@@ -1070,7 +1070,7 @@ handleClientMessage conn state = \case
   RestartDevnet -> do
     case getHydraPayMode state of
       ConfiguredMode {} -> pure $ ApiError "Hydra Pay is currently not running a Devnet"
-      LiveDocMode -> do
+      ManagedDevnetMode -> do
         heads <- Map.keys <$> (liftIO $ readMVar (_state_heads state))
         -- Terminate all the heads!
         for_ heads $ terminateHead state

--- a/backend/src/HydraPay/Server.hs
+++ b/backend/src/HydraPay/Server.hs
@@ -222,7 +222,7 @@ makeCardanoNodeStateAndRestartDemoDevnet = \case
         pure $ HydraSharedInfo
           { _hydraScriptsTxId = T.unpack scriptsTxId,
             _hydraLedgerGenesis = "devnet/genesis-shelley.json",
-            _hydraLedgerProtocolParameters = "devnet/protocol-parameters.json",
+            _hydraLedgerProtocolParameters = "devnet/hydra-protocol-parameters.json",
             _hydraCardanoNodeInfo = cardanoDevnetNodeInfo
           }
       _ <- lift $ withLogging $ seedTestAddresses (_hydraCardanoNodeInfo hydraSharedInfo) devnetFaucetKeys 10

--- a/backend/src/HydraPay/Server.hs
+++ b/backend/src/HydraPay/Server.hs
@@ -475,8 +475,8 @@ initHead state (HeadInit name con) = do
 
 data WithdrawRequest = WithdrawRequest
   { withdraw_address :: Address
-  -- | Nothing to redraw all.
   , withdraw_amount :: Maybe Lovelace
+  -- | ^ Nothing to withdraw all.
   }
   deriving(Eq, Show, Generic)
 

--- a/backend/src/HydraPay/Server.hs
+++ b/backend/src/HydraPay/Server.hs
@@ -639,7 +639,6 @@ submitTxOnHead state addr (HeadSubmitTx name toAddr lovelaceAmount) = do
 
     startTime <- lift $ liftIO $ getCurrentTime
     liftIO $ _node_send_msg node $ NewTx . T.pack $ txCborHexStr
-    -- TODO: Could we make sure we saw the transaction that we sent and not another one?
     untilJust $ do
       x <- liftIO . atomically $ readTChan c
       case x of
@@ -647,7 +646,7 @@ submitTxOnHead state addr (HeadSubmitTx name toAddr lovelaceAmount) = do
           let confirmedIds = mapMaybe (parseMaybe (withObject "tx" (.: "id"))) confirmeds
           if txid `elem` confirmedIds
             then do
-              endTime <- liftIO $ getCurrentTime
+              endTime <- liftIO getCurrentTime
               pure . Just $ nominalDiffTimeToSeconds $ diffUTCTime endTime startTime
             else pure Nothing
 

--- a/backend/src/HydraPay/Server.hs
+++ b/backend/src/HydraPay/Server.hs
@@ -86,8 +86,8 @@ import System.IO (hClose)
 import Control.Monad.Trans.Maybe (runMaybeT, MaybeT (MaybeT))
 import System.IO.Temp (withTempFile)
 import Hydra.Snapshot as Snapshot
-import qualified Config as Config
-import Config (HydraPayMode(..), HydraPayConfig(_hydraPayMode))
+import qualified HydraPay.Config as Config
+import HydraPay.Config (HydraPayMode(..), HydraPayConfig(_hydraPayMode))
 
 -- | The location where we store cardano and hydra keys
 getKeyPath :: IO FilePath
@@ -1164,6 +1164,8 @@ handleClientMessage conn state = \case
     removeHead state name
     broadcastToSubscribers state name $ HeadRemoved name
     pure $ HeadRemoved name
+
+  GetHydraPayMode -> pure . HydraPayMode . getHydraPayMode $ state
 
 newtype HydraPayClient a = HydraPayClient
   { unHydraPayClient :: MaybeT (ReaderT ClientState IO) a

--- a/backend/src/HydraPay/Server.hs
+++ b/backend/src/HydraPay/Server.hs
@@ -268,9 +268,10 @@ websocketApiHandler state = do
                     authResult = apiKey == sentKey
                 modifyMVar_ authVar (pure . const authResult)
                 pure . Aeson.encode . Tagged t $ AuthResult authResult
-              -- Allow GetHydraPayMode even when not authenticated
-              (_, Right GetHydraPayMode) -> do
-                fmap Aeson.encode $ withLogging $ handleTaggedMessage conn state (Tagged t GetHydraPayMode)
+              -- Allow GetIsManagedDevnet even when not authenticated to allow the
+              -- live docs to make this distinction upon loading.
+              (_, Right GetIsManagedDevnet) -> do
+                fmap Aeson.encode $ withLogging $ handleTaggedMessage conn state (Tagged t GetIsManagedDevnet)
               -- Turn away requests that aren't authenticated
               (False, Right _) ->
                 pure . Aeson.encode . Tagged t $ NotAuthenticated
@@ -1167,6 +1168,7 @@ handleClientMessage conn state = \case
     broadcastToSubscribers state name $ HeadRemoved name
     pure $ HeadRemoved name
 
+  GetIsManagedDevnet -> pure . IsManagedDevnet . (== ManagedDevnetMode) . getHydraPayMode $ state
   GetHydraPayMode -> pure . HydraPayMode . getHydraPayMode $ state
 
   GetProxyInfo address -> do

--- a/backend/src/ParseConfig.hs
+++ b/backend/src/ParseConfig.hs
@@ -1,41 +1,9 @@
-module Config where
+module ParseConfig where
 
 import Options.Applicative
 import Data.Semigroup ((<>))
 import Data.Maybe (fromMaybe)
-
-data HydraPayConfig = HydraPayConfig
-  { _hydraPayMode :: HydraPayMode
-  , _port :: Int
-  , _bind :: String
-  }
-  deriving (Show,Read)
-
--- | Configure Cardano (L1) and Hydra networks. This is either an
--- explicit configuration for Cardano Node and Hydra Nodes, or the
--- default mode which runs a devnet for live documentation.
-data HydraPayMode
-  = ManagedDevnetMode
-  | ConfiguredMode
-    { _cardanoNodeParams :: CardanoNodeParams
-    , _hydraNodeParams :: HydraNodeParams
-    }
-  deriving (Show,Read)
-
-data CardanoNodeParams = CardanoNodeParams
-  { _testnetMagic :: Int
-  , _nodeSocket :: FilePath
-  , _ledgerGenesis :: FilePath
-  , _ledgerProtocolParameters :: FilePath
-  }
-  deriving (Show,Read)
-
-data HydraNodeParams = HydraNodeParams
-  { _hydraScriptsTxId :: String
-  , _hydraLedgerProtocolParameters :: FilePath
-  , _hydraLedgerGenesis :: FilePath
-  }
-  deriving (Show,Read)
+import HydraPay.Config
 
 -- | Obelisk's 'ob run' passes a "--quiet". This parser
 -- transformer ignores "--quiet".
@@ -65,8 +33,7 @@ nodeParamsParser =
   (CardanoNodeParams
    <$> option auto (long "testnet-magic")
    <*> strOption (long "node-socket")
-   <*> strOption (long "ledger-genesis")
-   <*> strOption (long "ledger-protocol-parameters"))
+   <*> strOption (long "ledger-genesis"))
   <*>
   (HydraNodeParams
    <$> strOption (long "hydra-scripts-tx-id")

--- a/common/common.cabal
+++ b/common/common.cabal
@@ -42,5 +42,6 @@ library
     Hydra.ClientInput
     Hydra.Snapshot
     HydraPay.Api
+    HydraPay.Config
 
   ghc-options: -Wall -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -O -fno-show-valid-hole-fits

--- a/common/common.cabal
+++ b/common/common.cabal
@@ -1,6 +1,6 @@
 name: common
 version: 0.1
-cabal-version: >= 1.2
+cabal-version: >= 1.10
 build-type: Simple
 
 library

--- a/common/src/HydraPay/Api.hs
+++ b/common/src/HydraPay/Api.hs
@@ -152,6 +152,7 @@ data ClientMsg
   | LiveDocEzSubmitTx Tx Address
 
   | GetHydraPayMode
+  | GetProxyInfo Address
   deriving (Eq, Show, Generic)
 
 instance ToJSON ClientMsg
@@ -189,10 +190,24 @@ data ServerMsg
   | HeadRemoved HeadName
   | ApiError T.Text
   | HydraPayMode Config.HydraPayMode
+  | ProxyAddressInfo ProxyInfo
   deriving (Eq, Show, Generic)
 
 instance ToJSON ServerMsg
 instance FromJSON ServerMsg
+
+-- | Information about the managed proxy-address
+-- for a specific address
+data ProxyInfo = ProxyInfo
+  { proxyInfo_address :: Address
+  , proxyInfo_proxyAddress :: Address
+  , proxyInfo_balance :: Lovelace
+  , proxyInfo_fuel :: Lovelace
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON ProxyInfo
+instance FromJSON ProxyInfo
 
 data ApiMsg
   = TaggedMsg (Tagged ServerMsg)

--- a/common/src/HydraPay/Api.hs
+++ b/common/src/HydraPay/Api.hs
@@ -14,6 +14,7 @@ import Control.Lens.TH
 import Data.Fixed (Pico)
 import Hydra.Types
 import Hydra.ServerOutput as ServerOutput
+import qualified HydraPay.Config as Config
 
 type HeadName = T.Text
 
@@ -149,6 +150,8 @@ data ClientMsg
   | GetHeadBalance HeadName Address
 
   | LiveDocEzSubmitTx Tx Address
+
+  | GetHydraPayMode
   deriving (Eq, Show, Generic)
 
 instance ToJSON ClientMsg
@@ -185,6 +188,7 @@ data ServerMsg
   | BalanceChange HeadName (Map Address Lovelace)
   | HeadRemoved HeadName
   | ApiError T.Text
+  | HydraPayMode Config.HydraPayMode
   deriving (Eq, Show, Generic)
 
 instance ToJSON ServerMsg

--- a/common/src/HydraPay/Api.hs
+++ b/common/src/HydraPay/Api.hs
@@ -150,7 +150,7 @@ data ClientMsg
   | GetHeadBalance HeadName Address
 
   | LiveDocEzSubmitTx Tx Address
-
+  | GetIsManagedDevnet
   | GetHydraPayMode
   | GetProxyInfo Address
   deriving (Eq, Show, Generic)
@@ -190,6 +190,7 @@ data ServerMsg
   | HeadRemoved HeadName
   | ApiError T.Text
   | HydraPayMode Config.HydraPayMode
+  | IsManagedDevnet Bool
   | ProxyAddressInfo ProxyInfo
   deriving (Eq, Show, Generic)
 

--- a/common/src/HydraPay/Config.hs
+++ b/common/src/HydraPay/Config.hs
@@ -1,0 +1,45 @@
+module HydraPay.Config where
+
+import Data.Aeson.Types (FromJSON, ToJSON)
+import GHC.Generics (Generic)
+
+data HydraPayConfig = HydraPayConfig
+  { _hydraPayMode :: HydraPayMode
+  , _port :: Int
+  , _bind :: String
+  }
+  deriving (Show,Read)
+
+-- | Configure Cardano (L1) and Hydra networks. This is either an
+-- explicit configuration for Cardano Node and Hydra Nodes, or the
+-- default mode which runs a devnet for live documentation.
+data HydraPayMode
+  = ManagedDevnetMode
+  | ConfiguredMode
+    { _cardanoNodeParams :: CardanoNodeParams
+    , _hydraNodeParams :: HydraNodeParams
+    }
+  deriving (Eq,Show,Read,Generic)
+
+instance ToJSON HydraPayMode
+instance FromJSON HydraPayMode
+
+data CardanoNodeParams = CardanoNodeParams
+  { _testnetMagic :: Int
+  , _nodeSocket :: FilePath
+  , _ledgerGenesis :: FilePath
+  }
+  deriving (Eq,Show,Read,Generic)
+
+instance ToJSON CardanoNodeParams
+instance FromJSON CardanoNodeParams
+
+data HydraNodeParams = HydraNodeParams
+  { _hydraScriptsTxId :: String
+  , _hydraLedgerProtocolParameters :: FilePath
+  , _hydraLedgerGenesis :: FilePath
+  }
+  deriving (Eq,Show,Read,Generic)
+
+instance ToJSON HydraNodeParams
+instance FromJSON HydraNodeParams

--- a/frontend/frontend.cabal
+++ b/frontend/frontend.cabal
@@ -1,6 +1,6 @@
 name: frontend
 version: 0.1
-cabal-version: >= 1.8
+cabal-version: >= 1.10
 build-type: Simple
 
 library

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -3,6 +3,7 @@
 {-# OPTIONS_GHC -Wno-unused-local-binds #-}
 {-# OPTIONS_GHC -Wno-type-defaults #-}
 {-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module Frontend
   ( frontend
@@ -44,6 +45,8 @@ import Control.Monad.Fix
 
 import Language.Javascript.JSaddle (MonadJSM, jsg, js, js1, liftJSM, fromJSValUnchecked)
 import Data.Bool (bool)
+import HydraPay.Config (HydraPayMode (ManagedDevnetMode, ConfiguredMode), CardanoNodeParams (..))
+import Data.String.Interpolate ( iii, __i )
 
 default (T.Text)
 
@@ -68,6 +71,7 @@ frontend = Frontend
 
   , _frontend_body = elAttr "div" ("class" =: "w-screen h-screen overflow-hidden flex flex-col bg-gray-100" <> "style" =: "font-family: 'Inter', sans-serif;") $ do
       prerender_ (text "Loading Live Documentation") $ do
+        pb <- getPostBuild
         endpoint <- liftJSM $ do
           let
             webSocketProtocol :: T.Text -> T.Text
@@ -106,7 +110,13 @@ frontend = Frontend
 
           (_, sendMsg :: Event t [ClientMsg]) <- runEventWriterT $ elClass "div" "w-full h-full flex flex-row text-gray-700" $ do
             activeHeads authenticated lastTagId subscriptions responses
-            monitorView lastTagId responses
+            hydraPayModeReply <- requester lastTagId responses (GetHydraPayMode <$ pb)
+            runWithReplace blank $
+              mapMaybe ((\case
+                            HydraPayMode hpm -> Just (monitorView lastTagId responses hpm)
+                            _ -> Nothing)
+                         . tagged_payload)
+              hydraPayModeReply
             elClass "div" "flex-grow" $ elClass "div" "max-w-lg" blank
         pure ()
   }
@@ -392,8 +402,8 @@ sendFundsInHead lastTagId serverMsg = do
     header "Transactions in a Head"
 
     elClass "p" "" $ do
-      text "Once a Head is Open (All participants have commited UTxOs), you are free to move funds around withing the head by creating transactions."
-      text " You will get BalanceChanged payloads if you are subscribed to the Head, we are using this payload in the Live Documentation to live update the balance of all participants in the Head in the \"Your Heads\" section"
+      text "Once a Head is Open (all participants have commited UTxOs), you are free to move funds around within the head by creating transactions."
+      text " You will get BalanceChanged payloads if you are subscribed to the Head. We are using this payload in the Live Documentation to live update the balance of all participants in the Head in the \"Your Heads\" section."
 
   let
     input = payloadInput $ do
@@ -551,8 +561,8 @@ fundingProxyAddresses ::
   , PostBuild t m
   , MonadFix m
   , MonadHold t m
-  ) => Dynamic t Int64 -> Event t (Tagged ServerMsg) -> m ()
-fundingProxyAddresses lastTagId serverMsg = do
+  ) => Dynamic t Int64 -> Event t (Tagged ServerMsg) -> HydraPayMode -> m ()
+fundingProxyAddresses lastTagId serverMsg hpm = do
   elClass "div" "px-4 pb-4" $ do
     header "Proxy Addresses"
 
@@ -562,16 +572,21 @@ fundingProxyAddresses lastTagId serverMsg = do
       el "br" blank
       el "br" blank
       text "Instead of participating directly in a Head, any participant will actually be mapped to a \"Proxy Address\"."
-      text " This is a regular cardano address that is created to hold funds and fuel for said participant in Hydra Pay Head."
+      text " This is a regular cardano address that is created to hold funds and fuel for said participant in a Hydra Pay Head."
 
   elClass "div" "px-4 pb-4" $ do
     header "Funding Proxy Addresses | Funds & Fuel"
 
     elClass "p" "" $ do
-      text "To participate in a Hydra Pay managed Head you need to transfer funds to your Proxy Address, you must transfer both Funds and Fuel."
-      el "br" blank
-      el "br" blank
-      hintText $ text "Hydra Pay manages its own devnet, so we can conveniently allow you to submit transactions for testing purposes, give it a try!"
+      text "To participate in a Hydra Pay managed Head you need to transfer funds from your address to your Proxy Address. You must transfer both regular Ada and a specially tagged Fuel transaction yourself."
+    elClass "p" "" $ do
+      text "For your convenience Hydra Pay provides endpoints which return draft transactions for both types of funds. However, you yourself must sign and submit these transactions with the signing key for your address."
+
+    hintText $ text $ case hpm of
+        ManagedDevnetMode  ->
+          "Since you're running Hydra Pay in managed-devnet mode, we can conveniently submit transactions for you. Give it a try!"
+        ConfiguredMode {} ->
+          "You're running Hydra Pay with an externally managed Cardano network. After you request the funding transactions, we'll provide shell commands for you to submit them."
 
   let
     input = payloadInput $ do
@@ -613,7 +628,30 @@ fundingProxyAddresses lastTagId serverMsg = do
 
       pure $ GetAddTx <$> txType <*> addr <*> amount
 
+  -- TODO: make sure we say that this has to be an address with funds
+
   let
+    shellCommands cardanoParams req = \case
+      FundsTx tx -> elClass "div" "my-4" $ do
+        elClass "div" "font-semibold my-4" $ text "Submitting the transaction"
+        elClass "p" "my-4" $ text "To submit the transaction on your Cardano net you can execute the shell commands below. Remember to fill in the path to your signing key file."
+        elClass "pre" "overflow-y-scroll" $ text $
+          [__i|
+              cat > unsigned-tx.json<< EOF
+                #{Aeson.encodePretty tx}
+              EOF
+
+              cardano-cli transaction sign \\
+                --tx-body-file unsigned-tx.json \\
+                --out-file signed.json \\
+                --signing-key-file [PATH-TO-SIGNING-KEY]
+
+              CARDANO_NODE_SOCKET_PATH=#{_nodeSocket cardanoParams} \\
+                cardano-cli transaction submit \\
+                --tx-file signed.json \\
+                --testnet-magic #{_testnetMagic cardanoParams}
+              |]
+      _ -> blank
     submitTxButton req = \case
       FundsTx tx -> elClass "div" "mt-4" $ do
         rec
@@ -664,7 +702,9 @@ fundingProxyAddresses lastTagId serverMsg = do
     "Ledger Cddl Format"
     )
     (const Nothing)
-    submitTxButton
+    (case hpm of
+       ManagedDevnetMode -> submitTxButton
+       ConfiguredMode cardanoParams _ -> shellCommands cardanoParams)
 
   pure ()
 
@@ -684,7 +724,7 @@ payloadInput input = do
 
 hintText :: DomBuilder t m => m a -> m a
 hintText action = do
-  elClass "span" "text-gray-400 font-semibold italic" action
+  elClass "div" "text-gray-400 font-semibold italic my-4" action
 
 subscribeTo ::
   ( EventWriter t [ClientMsg] m
@@ -699,11 +739,10 @@ subscribeTo lastTagId serverMsg = do
 
     elClass "p" "" $ do
       text "A lot of the time the logic for your DApp or Light Wallet will include waiting for certain state changes to take place."
-      text " To be convenient for developers and to avoid unecessary complications and resource usage of polling, you can subscribe to state changes of certain heads"
-      text " For example if you create a head you should subscribe to it."
-      el "br" blank
-      el "br" blank
-      hintText $ text "When you subscribe to updates for a head in the live documentation, we will automatically update the view in \"Your Heads\""
+      text " To be convenient for developers and to avoid unecessary complications and resource usage of polling, you can subscribe to state changes of certain heads."
+      text " If you create a head you should subscribe to it as well."
+
+    hintText $ text "When you subscribe to updates for a head in the live documentation, we will automatically update the view in \"Your Heads\"."
 
   let
     input = do
@@ -749,9 +788,8 @@ headCreation lastTagId serverMsg = do
     elClass "p" "" $ do
       text "To create a Head you will give it a friendly name and list the addresses that will become the participants."
       text " Creating the head starts the Hydra network."
-      el "br" blank
-      el "br" blank
-      elClass "span" "italic" $ text " This request may take some time as Hydra Pay waits for all Hydra Nodes to respond"
+
+    hintText $ text " This request may take some time as Hydra Pay waits for all Hydra Nodes to respond."
 
   elClass "div" "p-4 bg-white rounded flex flex-col" $ do
     let
@@ -869,7 +907,7 @@ theDevnet lastTagId serverMsg = do
           elClass "div" "flex flex-col" $ do
             ie <- inputElement $ def
               & initialAttributes .~ ("class" =: "border px-2" <> "type" =: "number")
-              & inputElementConfig_initialValue .~ "1"
+              & inputElementConfig_initialValue .~ "2"
             pure $ GetDevnetAddresses . maybe 1 id . readMaybe . T.unpack <$> _inputElement_value ie
 
       (tryEl, _) <- elClass' "div" "mb-4" $ elClass "button" "flex-grow-0 rounded-md px-4 py-1 text-center bg-green-500 text-white font-bold border-2 border-green-600" $ text "Try Request"
@@ -953,7 +991,7 @@ sayHello lastTagId serverMsg = do
 
     elClass "p" "" $ do
       text "This Live Documentation is currently connected to your Hydra Pay instance, this allows you to easily verify if things are set up and working, and try requests and see responses."
-      text " Lets say hello to the Hydra Pay instance, hit Try Request to send a ClientHello payload to Hydra Pay."
+      text " Let's say hello to the Hydra Pay instance. Hit Try Request to send a ClientHello payload to Hydra Pay."
 
   let
     request = pure ClientHello
@@ -1039,8 +1077,14 @@ authentication lastTagId serverMsg = do
     header "Authentication"
 
     elClass "p" "" $ do
-      text "When you launch or deploy a Hydra Pay instance you will need to provide an API Key to authenticate against, this is a secret that should be only known to your DApp/LightWallet and your Hydra Pay instance."
-      text "Upon opening a websocket connection to your HydraPay instance, you should immediately Authenticate by sending a Tagged `Authenticate` request (see below)."
+      text [iii|
+             When you launch or deploy a Hydra Pay instance you will
+             need to provide an API Key to authenticate against.
+             This is a secret that should be only known to your
+             DApp/LightWallet and your Hydra Pay instance.
+             Upon opening a websocket connection to your HydraPay instance,
+             you should immediately Authenticate by sending a Tagged `Authenticate` request (see below).
+           |]
 
   elClass "div" "p-4 bg-white rounded flex flex-col relative" $ do
     (tryButton, _) <- elClass "div" "flex flex-row justify-between" $ do
@@ -1103,9 +1147,9 @@ authentication lastTagId serverMsg = do
 
     expectedResponse $ AuthResult True
 
-  elClass "p" "p-4"$
+  elClass "p" "p-4 my-8"$
     elClass "span" "text-gray-600 font-semibold" $ do
-    text "Ensure you have authenticated before trying the requests below"
+    text "Ensure you have authenticated before trying the requests below."
 
 monitorView ::
   ( PostBuild t m
@@ -1115,8 +1159,8 @@ monitorView ::
   , MonadJSM (Performable m)
   , PerformEvent t m
   , EventWriter t [ClientMsg] m
-  ) => Dynamic t Int64 -> Event t (Tagged ServerMsg) -> m ()
-monitorView lastTagId serverMsg = do
+  ) => Dynamic t Int64 -> Event t (Tagged ServerMsg) -> HydraPayMode -> m ()
+monitorView lastTagId serverMsg hpm = do
   elClass "div" "h-full text-gray-700 max-w-4xl overflow-y-scroll rounded flex flex-col flex-shrink-0" $ do
     elClass "div" "p-4" $ do
       elClass "div" "text-3xl font-bold flex flex-row items-center justify-between" $ do
@@ -1125,37 +1169,55 @@ monitorView lastTagId serverMsg = do
       -- Divider
       elClass "div" "mt-4 w-full h-px bg-gray-200" blank
 
-      elClass "div" "text-xl mt-8 mb-2 font-semibold" $ text "Websocket API"
+      elClass "p" "my-4" $ do
+        text [iii|
+               This page provides hands-on documentation of the Hydra
+               Pay API. You can try out every request against your
+               configured Cardano network. If you didn't specify any,
+               Hydra Pay will have started a devnet for you with
+               pre-funded addresses. This page is fully implemented
+               using the Hydra Pay API and thus also serves as an
+               example of its use.
+               |]
+
+      elClass "div" "text-xl mt-12 mb-2 font-semibold" $ text "Websocket API"
       elClass "div" "my-2 w-full h-px bg-gray-200" blank
       elClass "p" "" $ do
         text "The Hydra Pay API is a websocket based API that gives you all that you need to manage and monitor heads, securely. The endpoint to connect to the Hydra Pay websocket is /hydra/api."
-        text " Once you are connected you must authenticate via your Authentication Token you have set for your Hydra Pay Instance."
+        text " Once you are connected you must authenticate via the Authentication Token you have set for your Hydra Pay Instance."
         text " In this section Client refers to the developer, and Server refers to the running Hydra Pay instance reachable at /hydra/api/."
-        el "br" blank
-        el "br" blank
-        text " In this Live Documentation we Tag the requests automatically, and when viewing the JSON payload of a request you may always see the tagged equivalent, we even auto increment the request id,"
-        text " this makes it easy to ensure you are sending the right information to Hydra Pay."
 
       -- Header
-      elClass "div" "text-xl mt-8 mb-2 font-semibold" $ text "Tagging"
-      elClass "div" "my-2 w-full h-px bg-gray-200" blank
+      elClass "div" "text-lg mt-8 mb-2 font-semibold" $ text "Tagging"
 
-      elClass "p" "" $ do
-        text "All communication the Client does with the Server through the WebSocket must be Tagged."
-        text " To Tag a message, we need the unique request-id, if we were sending this as the first message to our Server we may use 0 as the request-id."
-        text " Remember that all communication the Client makes with the Server must be tagged. This forms the request response part of the API."
+      elClass "p" "my-4" $ do
+        text [iii|
+          The Hydra Pay WebSocket API comes with a convenient scheme to keep track of responses to specific requests.
+          Each request must be tagged with an identifying value as follows:|]
+      elClass "pre" "my-4" . text $ [__i|{ "tagged_payload": REQUEST, "tagged_id": ID }|]
+      elClass "p" "my-4" $ text [iii|When the server replies this identifier will be included:|]
+      elClass "pre" "my-4" . text $ [__i|{ "tagged_payload": REPLY, "tagged_id": ID }|]
+
+      elClass "p" "my-4" $ do
+        text [iii|
+          In this Live Documentation we tag the requests
+          automatically and hide the tagging by default. When viewing the JSON payload of a
+          request you can always look at the tagged equivalent by checking "Show Tagged".
+          |]
 
     authentication lastTagId serverMsg
 
     sayHello lastTagId serverMsg
 
-    theDevnet lastTagId serverMsg
+    case hpm of
+      ManagedDevnetMode -> theDevnet lastTagId serverMsg
+      _ -> blank
 
     headCreation lastTagId serverMsg
 
     subscribeTo lastTagId serverMsg
 
-    fundingProxyAddresses lastTagId serverMsg
+    fundingProxyAddresses lastTagId serverMsg hpm
 
     initHead lastTagId serverMsg
 

--- a/livedoc-devnet/bin/prepare-devnet.sh
+++ b/livedoc-devnet/bin/prepare-devnet.sh
@@ -14,7 +14,7 @@ chmod +w -R "$TARGETDIR"
 cp -rf "$BASEDIR/config/credentials" "$TARGETDIR"
 chmod +w -R "$TARGETDIR/credentials"
 
-cp -rf "$BASEDIR/config/protocol-parameters.json" "$TARGETDIR"
+cp -rf "$BASEDIR/config/protocol-parameters.json" "$TARGETDIR/hydra-protocol-parameters.json"
 echo '{"Producers": []}' > "$TARGETDIR/topology.json"
 sed -i "s/\"startTime\": [0-9]*/\"startTime\": $(date +%s)/" "$TARGETDIR/genesis-byron.json" && \
 sed -i "s/\"systemStart\": \".*\"/\"systemStart\": \"$(date -u +%FT%TZ)\"/" "$TARGETDIR/genesis-shelley.json"


### PR DESCRIPTION
This edits the live docs and improves wording. The live docs are also made more suitable for use with a configured Cardano network by providing shell commands to fund the proxy addresses. Finally, a new endpoint is added for querying the state of the proxy addresses.