### PR TITLE
Prevent misuse of documentation addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Example payload:
 ``` json
 {
     "contents": {
-        "headCreate_participants": ["addr_test1vpperccj7n8faw74ketx68k2mehg23d864hvg209cgupp5c4r47hp"],
+        "headCreate_participants": ["addr_test1thisaddressisobviouslyinvaliddonotusethisaddressplease"],
         "headCreate_name": "test"
     },
     "tag": "CreateHead"
@@ -302,7 +302,7 @@ Example Payload:
 {
     "contents": {
         "headCommit_name": "test",
-        "headCommit_participant": "addr_test1vpnpz04x65gmwcw25xr7p6spehmpmtakq885j92sprz7hggsnlm4a",
+        "headCommit_participant": "addr_test1thisaddressisobviouslyinvaliddonotusethisaddressplease",
         "headCommit_amount": 100000000
     },
     "tag": "CommitHead"
@@ -421,7 +421,7 @@ Example Payload:
 ``` json
 {
   "tag": "Withdraw"
-  "contents": "addr_test1vpperccj7n8faw74ketx68k2mehg23d864hvg209cgupp5c4r47hp",
+  "contents": "addr_test1thisaddressisobviouslyinvaliddonotusethisaddressplease",
 }
 ```
 

--- a/common/src/Hydra/Types.hs
+++ b/common/src/Hydra/Types.hs
@@ -37,13 +37,22 @@ addressToString :: Address -> String
 addressToString = T.unpack . unAddress
 
 parseAddress :: T.Text -> Either String Address
-parseAddress = parseOnly parser
+parseAddress t =
+  case parseOnly parser t of
+    Left err -> Left err
+    Right addr ->
+      case addr == obviouslyInvalidAddress of
+        True -> Left "This is Hydra Pay example cardano address, rejecting request"
+        False -> Right addr
   where
     parser = do
       prefix <- string "addr1" <|> string "addr_test1"
       rest <- takeWhile1 (\x -> isDigit x || isAlpha_ascii x)
       endOfInput
       pure $ UnsafeToAddress $ prefix <> rest
+
+obviouslyInvalidAddress :: Address
+obviouslyInvalidAddress = UnsafeToAddress "addr_test1thisaddressisobviouslyinvaliddonotusethisaddressplease"
 
 type Lovelace = Integer
 

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -934,8 +934,8 @@ theDevnet lastTagId serverMsg = do
 
       Nothing -> blank
 
-    responseVisualizer "Example Response" $ DevnetAddresses [ UnsafeToAddress "addr_test1vpnpz04x65gmwcw25xr7p6spehmpmtakq885j92sprz7hggsnlm4a"
-                                                            , UnsafeToAddress "addr_test1vr6mp9zqpxk5nw7p3xm6kvnt2w6mgl9lhmzuvuez5v59hqgakn855"
+    responseVisualizer "Example Response" $ DevnetAddresses [ obviouslyInvalidAddress
+                                                            , obviouslyInvalidAddress
                                                             ]
 
 

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -1015,7 +1015,7 @@ responseVisualizer name msg = do
   -- Divider
   elClass "div" "mt-6 w-full h-px bg-gray-200" blank
 
-  elClass "div" "font-semibold mt-4 mb-2" $ text name
+  elClass "div" "font-semibold text-sm text-gray-400 mt-4 mb-2" $ text name
   elClass "div" "" $
     elClass "pre" "overflow-x-scroll relative rounded-lg p-4 border bg-gray-900 text-green-500" $ elClass "code" "language-json" $
     text $ decodeUtf8 . LBS.toStrict . Aeson.encodePretty $ msg


### PR DESCRIPTION
This adjust the documentation and the addresses used to avoid accidental issues when reading the documentation or using the livedocs.

This also gives better error message when you try and construct transactions and you:
- Don't have the funds
- Can't cover the fees
- Have no ada at all