### PR TITLE
Change from a proxy address scheme to a proxy per node scheme

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ This project's release branch is `master`. This log is written from the perspect
 * Ensure absolute paths for cardano-cli & hydra-tools executables
 * Delegate SIGINT to cardano-node process
 * Reduce the number of reconnections to Hydra Node websocket api
+* Bump to hydra 0.10.0
 
 ### Version v0.2.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,16 @@ This project's release branch is `master`. This log is written from the perspect
 
 ### Unreleased
 
+* Ensure Hydra Node interaction threads currently executing blocking calls when asked to close; close immediately when execution is yielded back to them
+* Proxies now pay directly back to their L1 counterpart when they receive the UTxO from a finalized head
+* Automatic transaction batching, when HydraPay is instructed to pay to or out of proxy addresses; instead of submitting separate transactions it will now batch to the best of its ability to limit transaction wait times, and avoid contention 
+* Automated state progression: When a head is started, we use information from the proxy addresses, and the hydra nodes to automatically send Client inputs to the head, meaning the lifecycle is now self-managing and self-repairing
+* Internal indexer: We now do our best to scrutinize and persist events observed by each node on each head
+* Add a worker to handle refunds when nodes fail to start for any reason
+* Introduce Task Workers: A way for various internal HydraPay actions to happen in parallel with reliable execution and smart retries 
+* More reliable and less resource intensive Hydra Node/Head status tracking: The communication interface uses less threads and a single and output channel
+* Automatically restart nodes at runtime
+* Rework proxy system to have one proxy per node to be in line with Hydra best practices
 * Ensure absolute paths for cardano-cli & hydra-tools executables
 * Delegate SIGINT to cardano-node process
 * Reduce the number of reconnections to Hydra Node websocket api

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ We assume at this time you are knowledgeable about Hydra and the basic Hydra Hea
 
 First party haskell libraries `hydra-pay-core` and `hydra-pay` provide direct access to powerful features like:
 * A simple, powerful, and customizable logger with automatic rotation, file size limits, and file management.
+* A set of workers to carry out tasks in parallel, maximizing throughput. 
+* Automated transaction batching to have the least downtime when waiting for L1 transactions to be observed on-chain.
+* An automated process for moving heads through the lifecycle based on indexer and on-chain information.
+* Automated refunding of L1 addresses when failures are detected, ensuring your funds are always sent back to you.
+* Automatic restarting of Hydra Nodes so you never lose your state (or funds).
+* An internal indexer that tracks head state in high detail.
 * Automated node management with integrated logging and error tracking, providing a convenient interface for interaction and information.
 * A typesafe GADT based interface into cardano-cli that allows easy:
   * Tip and Protocol Parameter queries

--- a/backend/src/HydraPay/Server.hs
+++ b/backend/src/HydraPay/Server.hs
@@ -35,7 +35,6 @@ import Data.Map (Map)
 import qualified Data.Set as Set
 import Data.Set (Set)
 import qualified Data.Map as Map
-import Data.Aeson ((.:))
 import Data.Aeson as Aeson
 import Data.Aeson.Types as Aeson
 import Data.Maybe
@@ -44,7 +43,6 @@ import System.IO ( IOMode(WriteMode), openFile, Handle, hClose )
 import Network.WebSockets.Client
 
 import Control.Monad.Reader
-import Control.Monad.Fail
 
 import Common.Helpers
 import HydraPay.Logging
@@ -78,7 +76,6 @@ import Control.Concurrent.STM (newBroadcastTChanIO, dupTChan, TChan)
 import Control.Monad.STM (atomically)
 import Control.Concurrent.STM.TChan (readTChan, writeTChan)
 import Control.Monad.Loops (untilJust, iterateUntilM)
-import Data.Aeson.Types (parseMaybe)
 import Control.Monad.Except
 import Control.Monad.Trans.Maybe (runMaybeT, MaybeT (MaybeT))
 import System.IO.Temp (withTempFile)
@@ -666,9 +663,9 @@ submitTxOnHead state addr (HeadSubmitTx name toAddr lovelaceAmount) =
             pure . Just $ nominalDiffTimeToSeconds $ diffUTCTime endTime startTime
           else pure Nothing
 
-      ServerOutput.TxInvalid headId theUtxo tx valError -> do
+      ServerOutput.TxInvalid headId_ theUtxo tx valError -> do
         let
-          parsedError = HydraPay.Api.TxInvalid headId theUtxo tx valError <$ (guard . (== txid) =<< parseMaybe (withObject "tx" (.: "id")) tx)
+          parsedError = HydraPay.Api.TxInvalid headId_ theUtxo tx valError <$ (guard . (== txid) =<< parseMaybe (withObject "tx" (.: "id")) tx)
         _ <- throwError $ fromMaybe (ProcessError "Tx Invalid") parsedError
         pure Nothing
       _ -> pure Nothing

--- a/default.nix
+++ b/default.nix
@@ -39,6 +39,7 @@ let
       };
 
       overrides = self: super: pd.overrides self super // {
+        bytestring-aeson-orphans = haskellLib.doJailbreak super.bytestring-aeson-orphans;
         aeson-gadt-th = haskellLib.doJailbreak (haskellLib.disableCabalFlag (self.callCabal2nix "aeson-gadt-th" deps.aeson-gadt-th {}) "build-readme");
         string-interpolate = haskellLib.doJailbreak (haskellLib.dontCheck super.string-interpolate);
 

--- a/default.nix
+++ b/default.nix
@@ -40,10 +40,7 @@ let
 
       overrides = self: super: pd.overrides self super // {
         aeson-gadt-th = haskellLib.doJailbreak (haskellLib.disableCabalFlag (self.callCabal2nix "aeson-gadt-th" deps.aeson-gadt-th {}) "build-readme");
-        reflex-gadt-api = haskellLib.doJailbreak (self.callCabal2nix "reflex-gadt-api" deps.reflex-gadt-api {});
         string-interpolate = haskellLib.doJailbreak (haskellLib.dontCheck super.string-interpolate);
-
-        bytestring-aeson-orphans = haskellLib.doJailbreak super.bytestring-aeson-orphans;
 
         cardano-transaction = haskellLib.overrideCabal super.cardano-transaction (drv: {
           librarySystemDepends = (drv.librarySystemDepends or []) ++ [

--- a/dep/cardano-project/git.json
+++ b/dep/cardano-project/git.json
@@ -1,8 +1,8 @@
 {
   "url": "ssh://git@code.obsidian.systems/lodewallet/cardano-project-definition.git",
-  "rev": "df1c35cb01cb864c5147653128232642f76a9cbe",
-  "sha256": "0kl8604prg0ych17bn3fqgslvm3czngy8ivdcvb2clcz52fqq4s2",
+  "rev": "7320416e2461e610c915e94d03dec010bf8813aa",
+  "sha256": "11902r3s12j8zkqkahi0pmws8y5jw9177y92pq5z5f4hlr63zn7q",
   "private": true,
   "fetchSubmodules": false,
-  "branch": "develop"
+  "branch": "ll/rhyolite-iv"
 }

--- a/dep/cardano-transaction-builder/github.json
+++ b/dep/cardano-transaction-builder/github.json
@@ -3,6 +3,6 @@
   "repo": "cardano-transaction-builder",
   "branch": "dango",
   "private": false,
-  "rev": "75977f3f977bff86a84a6e6e2c2adb4d7d63c59f",
-  "sha256": "1752g8jkpkkksjwxpz3wm2gl1qd1v1q1g698yyqjaqc17hmvynbp"
+  "rev": "1afde5654161ae355ffee16cd111883b3a0fa35b",
+  "sha256": "0ml9nzl9idj7i4aymfrfn3wpah5f1l3vf17b74ia8325zgm24iq3"
 }

--- a/dep/hydra/github.json
+++ b/dep/hydra/github.json
@@ -3,6 +3,6 @@
   "repo": "hydra-poc",
   "branch": "master",
   "private": false,
-  "rev": "0fab58f97b7ac955e8578215848e30b444cef8cb",
-  "sha256": "071qj948bjcr0dly3zm10cdad0a4axsfcq92n1139svdq3ffxmdz"
+  "rev": "8a8157d8cba4907e1653e2fbb87551cf7ddd59d8",
+  "sha256": "0jwg9i50ka436shjnclwiaak8r78x41dq0m7g9rh0d1qrf1wr8cf"
 }

--- a/hydra-pay-core/src/HydraPay/Cardano/Hydra/Api.hs
+++ b/hydra-pay-core/src/HydraPay/Cardano/Hydra/Api.hs
@@ -8,29 +8,35 @@ module HydraPay.Cardano.Hydra.Api
 
 import GHC.Generics
 import Data.Aeson
-import Data.Text (Text)
 import Data.Set (Set)
+import Data.Text (Text)
+import Data.Time (UTCTime)
 import HydraPay.Cardano.Hydra.Api.ClientInput as X hiding (utxo, transaction)
 
 type HeadId = Text
+type HeadStatus = Value
+type NodeId = Value
+type Party = Value
+type SnapshotNumber = Value
+type ValidationError = Value
 
 data ServerOutput
-  = PeerConnected {peer :: Value}
-  | PeerDisconnected {peer :: Value}
-  | HeadIsInitializing {headId :: HeadId, parties :: Set Value}
-  | Committed {headId :: HeadId, party :: Value, utxo :: Value}
+  = PeerConnected {peer :: NodeId}
+  | PeerDisconnected {peer :: NodeId}
+  | HeadIsInitializing {headId :: HeadId, parties :: Set Party}
+  | Committed {headId :: HeadId, party :: Party, utxo :: Value}
   | HeadIsOpen {headId :: HeadId, utxo :: Value}
   | HeadIsClosed
       { headId :: HeadId
-      , snapshotNumber :: Value
-      , -- | Nominal deadline until which contest can be submitted and after
-        -- which fanout is possible. NOTE: Use this only for informational
-        -- purpose and wait for 'ReadyToFanout' instead before sending 'Fanout'
-        -- as the ledger of our cardano-node might not have progressed
-        -- sufficiently in time yet and we do not re-submit transactions (yet).
-        contestationDeadline :: Value
+      , snapshotNumber :: SnapshotNumber
+      , contestationDeadline :: UTCTime
+      -- ^ Nominal deadline until which contest can be submitted and after
+      -- which fanout is possible. NOTE: Use this only for informational
+      -- purpose and wait for 'ReadyToFanout' instead before sending 'Fanout'
+      -- as the ledger of our cardano-node might not have progressed
+      -- sufficiently in time yet and we do not re-submit transactions (yet).
       }
-  | HeadIsContested {headId :: HeadId, snapshotNumber :: Value}
+  | HeadIsContested {headId :: HeadId, snapshotNumber :: SnapshotNumber}
   | ReadyToFanout {headId :: HeadId}
   | HeadIsAborted {headId :: HeadId, utxo :: Value}
   | HeadIsFinalized {headId :: HeadId, utxo :: Value}
@@ -40,7 +46,7 @@ data ServerOutput
     TxValid {headId :: HeadId, transaction :: Value}
   | -- | Given transaction was not not applicable to the given UTxO in time and
     -- has been dropped.
-    TxInvalid {headId :: HeadId, utxo :: Value, transaction :: Value, validationError :: Value}
+    TxInvalid {headId :: HeadId, utxo :: Value, transaction :: Value, validationError :: ValidationError}
   | -- | Given snapshot was confirmed and included transactions can be
     -- considered final.
     SnapshotConfirmed
@@ -52,10 +58,10 @@ data ServerOutput
   | InvalidInput {reason :: String, input :: Text}
   | -- | A friendly welcome message which tells a client something about the
     -- node. Currently used for knowing what signing key the server uses (it
-    -- only knows one).
-    Greetings {me :: Value}
+    -- only knows one), 'HeadStatus' and optionally (if 'HeadIsOpen' or
+    -- 'SnapshotConfirmed' message is emitted) UTxO's present in the Hydra Head.
+    Greetings {me :: Party, headStatus :: HeadStatus, snapshotUtxo :: Maybe Value}
   | PostTxOnChainFailed {postChainTx :: Value, postTxError :: Value}
-  | RolledBack
   deriving (Generic, Show)
 
 instance ToJSON ServerOutput

--- a/hydra-pay-core/src/HydraPay/Cardano/Hydra/RunningHead.hs
+++ b/hydra-pay-core/src/HydraPay/Cardano/Hydra/RunningHead.hs
@@ -31,9 +31,9 @@ data HydraNode = HydraNode
   , _hydraNode_processInfo :: TMVar ProcessInfo
   , _hydraNode_communicationThread :: TMVar ThreadId
   , _hydraNode_status :: TVar HydraNodeStatus
-  , _hydraNode_pendingRequests :: TMVar (Map Int HydraNodeRequest)
-  , _hydraNode_requestQueue :: TBQueue ClientInput
   , _hydraNode_runnerThread :: ThreadId
+  , _hydraNode_inputs :: TBQueue ClientInput
+  , _hydraNode_outputs :: TChan ServerOutput
   }
 
 data HydraNodeStatus

--- a/hydra-pay-core/src/HydraPay/Cardano/Hydra/RunningHead.hs
+++ b/hydra-pay-core/src/HydraPay/Cardano/Hydra/RunningHead.hs
@@ -28,11 +28,12 @@ type ProcessInfo = (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
 
 data HydraNode = HydraNode
   { _hydraNode_apiPort :: Port
-  , _hydraNode_processInfo :: ProcessInfo
-  , _hydraNode_communicationThread :: ThreadId
+  , _hydraNode_processInfo :: TMVar ProcessInfo
+  , _hydraNode_communicationThread :: TMVar ThreadId
   , _hydraNode_status :: TVar HydraNodeStatus
   , _hydraNode_pendingRequests :: TMVar (Map Int HydraNodeRequest)
   , _hydraNode_requestQueue :: TBQueue ClientInput
+  , _hydraNode_runnerThread :: ThreadId
   }
 
 data HydraNodeStatus

--- a/hydra-pay-core/src/HydraPay/PaymentChannel.hs
+++ b/hydra-pay-core/src/HydraPay/PaymentChannel.hs
@@ -38,14 +38,19 @@ data PaymentChannelManager = PaymentChannelManager
 makeLenses ''PaymentChannelManager
 
 data PaymentChannelStatus
-  = PaymentChannelStatus_Initializing
+  = PaymentChannelStatus_Unknown
+  | PaymentChannelStatus_Created
+  | PaymentChannelStatus_Funded
+  | PaymentChannelStatus_Initializing
   | PaymentChannelStatus_Initialized
   | PaymentChannelStatus_Opening
   | PaymentChannelStatus_Open
   | PaymentChannelStatus_Closing
   | PaymentChannelStatus_Closed
+  | PaymentChannelStatus_CanFanout
+  | PaymentChannelStatus_Finalized
   | PaymentChannelStatus_Error
-  deriving (Show, Eq, Ord, Read, Generic)
+  deriving (Show, Eq, Ord, Read, Generic, Enum)
 
 instance ToJSON PaymentChannelStatus
 instance FromJSON PaymentChannelStatus
@@ -99,8 +104,9 @@ isPending :: PaymentChannelStatus -> Bool
 isPending = \case
   PaymentChannelStatus_Initializing -> True
   PaymentChannelStatus_Initialized -> True
-  PaymentChannelStatus_Opening -> True
+  -- PaymentChannelStatus_Opening -> True
   PaymentChannelStatus_Open -> False
   PaymentChannelStatus_Closing -> False
   PaymentChannelStatus_Closed -> False
   PaymentChannelStatus_Error -> False
+  _ -> False

--- a/hydra-pay-core/src/HydraPay/PaymentChannel.hs
+++ b/hydra-pay-core/src/HydraPay/PaymentChannel.hs
@@ -38,10 +38,14 @@ data PaymentChannelManager = PaymentChannelManager
 makeLenses ''PaymentChannelManager
 
 data PaymentChannelStatus
-  = PaymentChannelOpen
-  | PaymentChannelOpening
-  | PaymentChannelPending UTCTime
-  deriving (Eq, Show, Generic)
+  = PaymentChannelStatus_Initializing
+  | PaymentChannelStatus_Initialized
+  | PaymentChannelStatus_Opening
+  | PaymentChannelStatus_Open
+  | PaymentChannelStatus_Closing
+  | PaymentChannelStatus_Closed
+  | PaymentChannelStatus_Error
+  deriving (Show, Eq, Ord, Read, Generic)
 
 instance ToJSON PaymentChannelStatus
 instance FromJSON PaymentChannelStatus
@@ -50,6 +54,7 @@ data PaymentChannelInfo = PaymentChannelInfo
   { _paymentChannelInfo_id :: Int32
   , _paymentChannelInfo_name :: Text
   , _paymentChannelInfo_createdAt :: UTCTime
+  , _paymentChannelInfo_expiry :: UTCTime
   , _paymentChannelInfo_other :: Text
   , _paymentChannelInfo_status :: PaymentChannelStatus
   , _paymentChannelInfo_initiator :: Bool
@@ -91,6 +96,11 @@ paymentChannelNeedsMyAcceptance pinfo =
   pinfo ^. paymentChannelInfo_status . to isPending && not (pinfo ^. paymentChannelInfo_initiator)
 
 isPending :: PaymentChannelStatus -> Bool
-isPending (PaymentChannelPending _) = True
-isPending PaymentChannelOpening = True
-isPending _ = False
+isPending = \case
+  PaymentChannelStatus_Initializing -> True
+  PaymentChannelStatus_Initialized -> True
+  PaymentChannelStatus_Opening -> True
+  PaymentChannelStatus_Open -> False
+  PaymentChannelStatus_Closing -> False
+  PaymentChannelStatus_Closed -> False
+  PaymentChannelStatus_Error -> False

--- a/hydra-pay-core/src/HydraPay/PaymentChannel.hs
+++ b/hydra-pay-core/src/HydraPay/PaymentChannel.hs
@@ -48,6 +48,7 @@ instance FromJSON PaymentChannelStatus
 data PaymentChannelInfo = PaymentChannelInfo
   { _paymentChannelInfo_id :: Int32
   , _paymentChannelInfo_name :: Text
+  , _paymentChannelInfo_createdAt :: UTCTime
   , _paymentChannelInfo_other :: Text
   , _paymentChannelInfo_status :: PaymentChannelStatus
   , _paymentChannelInfo_initiator :: Bool

--- a/hydra-pay-core/src/HydraPay/PaymentChannel.hs
+++ b/hydra-pay-core/src/HydraPay/PaymentChannel.hs
@@ -40,10 +40,8 @@ makeLenses ''PaymentChannelManager
 data PaymentChannelStatus
   = PaymentChannelStatus_Unknown
   | PaymentChannelStatus_Created
-  | PaymentChannelStatus_Initializing
   | PaymentChannelStatus_Initialized
   | PaymentChannelStatus_Open
-  | PaymentChannelStatus_Closing
   | PaymentChannelStatus_Closed
   | PaymentChannelStatus_Finalized
   | PaymentChannelStatus_Error

--- a/hydra-pay-core/src/HydraPay/PaymentChannel.hs
+++ b/hydra-pay-core/src/HydraPay/PaymentChannel.hs
@@ -39,6 +39,7 @@ makeLenses ''PaymentChannelManager
 
 data PaymentChannelStatus
   = PaymentChannelOpen
+  | PaymentChannelOpening
   | PaymentChannelPending UTCTime
   deriving (Eq, Show, Generic)
 
@@ -91,4 +92,5 @@ paymentChannelNeedsMyAcceptance pinfo =
 
 isPending :: PaymentChannelStatus -> Bool
 isPending (PaymentChannelPending _) = True
+isPending PaymentChannelOpening = True
 isPending _ = False

--- a/hydra-pay-core/src/HydraPay/Utils.hs
+++ b/hydra-pay-core/src/HydraPay/Utils.hs
@@ -33,6 +33,12 @@ withTMVar var action = do
   liftIO $ atomically $ putTMVar var a
   pure b
 
+withTMVar_ :: MonadIO m => TMVar a -> (a -> m a) -> m ()
+withTMVar_ var action = do
+  withTMVar var $ \a -> do
+    action a
+    pure (a, ())
+
 headMaybe :: [a] -> Maybe a
 headMaybe [] = Nothing
 headMaybe (x:_) = Just x

--- a/hydra-pay-core/src/HydraPay/Utils.hs
+++ b/hydra-pay-core/src/HydraPay/Utils.hs
@@ -100,6 +100,14 @@ txOutIsFuel (Api.TxOut _ _ datum _) = txOutDatumIsFuel datum
 fuelIsPresent :: Api.UTxO Api.BabbageEra -> Bool
 fuelIsPresent = not . Map.null . Map.filter (txOutIsFuel) . Api.unUTxO
 
+firstNonFuelUTxO :: Api.UTxO Api.BabbageEra -> Maybe (Api.UTxO Api.BabbageEra)
+firstNonFuelUTxO utxo = result
+  where
+    result = Map.foldrWithKey getValue Nothing nonFuelUtxos
+    nonFuelUtxos = Map.filter (not . txOutIsFuel) $ Api.unUTxO utxo
+    getValue k v b =
+      b <|> (Just $ Api.UTxO $ Map.singleton k v)
+
 mkCommitUTxOWithExactly :: Api.Lovelace -> Api.UTxO Api.BabbageEra -> Maybe (Api.UTxO Api.BabbageEra)
 mkCommitUTxOWithExactly wantedAmount utxo =
   trace ("Initial value: " <> show utxo) $ trace ("Final value: " <> show result) result

--- a/hydra-pay-core/src/HydraPay/Utils.hs
+++ b/hydra-pay-core/src/HydraPay/Utils.hs
@@ -2,6 +2,9 @@
 
 module HydraPay.Utils where
 
+import Debug.Trace
+import Control.Applicative
+import Data.Traversable
 import Data.Aeson as Aeson
 import Data.Text (Text, pack)
 import System.Exit
@@ -33,7 +36,7 @@ withTMVar var action = do
   liftIO $ atomically $ putTMVar var a
   pure b
 
-withTMVar_ :: MonadIO m => TMVar a -> (a -> m a) -> m ()
+withTMVar_ :: MonadIO m => TMVar a -> (a -> m ()) -> m ()
 withTMVar_ var action = do
   withTMVar var $ \a -> do
     action a
@@ -54,6 +57,9 @@ addressNetwork = \case
 
 isTestnetAddress :: Api.AddressAny -> Bool
 isTestnetAddress = maybe False (== Ledger.Testnet) . addressNetwork
+
+-- findCommitableUTxOWithExactly :: Api.Lovelace -> Api.UTxO Api.BabbageEra
+-- findCommitableUTxOWithExactly target utxos = undefined
 
 findUTxOWithExactly :: Api.Lovelace -> Api.UTxO Api.BabbageEra -> Maybe (Api.UTxO Api.BabbageEra)
 findUTxOWithExactly target utxos =
@@ -90,3 +96,17 @@ txOutDatumIsFuel _ = False
 
 txOutIsFuel :: Api.TxOut Api.CtxUTxO Api.BabbageEra -> Bool
 txOutIsFuel (Api.TxOut _ _ datum _) = txOutDatumIsFuel datum
+
+fuelIsPresent :: Api.UTxO Api.BabbageEra -> Bool
+fuelIsPresent = not . Map.null . Map.filter (txOutIsFuel) . Api.unUTxO
+
+mkCommitUTxOWithExactly :: Api.Lovelace -> Api.UTxO Api.BabbageEra -> Maybe (Api.UTxO Api.BabbageEra)
+mkCommitUTxOWithExactly wantedAmount utxo =
+  trace ("Initial value: " <> show utxo) $ trace ("Final value: " <> show result) result
+  where
+    result = Map.foldrWithKey getValue Nothing nonFuelUtxos
+    nonFuelUtxos = Map.filter (not . txOutIsFuel) $ Api.unUTxO utxo
+    getValue k v b =
+      b <|> (case txOutValue v == wantedAmount of
+        True -> trace "We found one!" $ Just $ Api.UTxO $ Map.singleton k v
+        False -> trace "We casn't use this one" $ Nothing)

--- a/hydra-pay/hydra-pay.cabal
+++ b/hydra-pay/hydra-pay.cabal
@@ -27,6 +27,7 @@ library
     , mtl
     , postgresql-simple
     , process
+    , rhyolite-beam-db
     , reflex
     , reflex-fsnotify
     , resource-pool
@@ -67,11 +68,13 @@ library
     HydraPay.Cardano.Hydra.Tools
     HydraPay.Cardano.Node
     HydraPay.Database
+    HydraPay.Database.Workers
     HydraPay.Host
     HydraPay.PaymentChannel.Postgres
     HydraPay.Proxy
     HydraPay.Transaction
     HydraPay.Watch
+    HydraPay.Worker
 
   ghc-options:
     -Wall -Wredundant-constraints -Wincomplete-uni-patterns

--- a/hydra-pay/hydra-pay.cabal
+++ b/hydra-pay/hydra-pay.cabal
@@ -28,6 +28,8 @@ library
     , postgresql-simple
     , process
     , rhyolite-beam-db
+    , rhyolite-beam-task-worker-backend
+    , rhyolite-beam-task-worker-types
     , reflex
     , reflex-fsnotify
     , resource-pool

--- a/hydra-pay/hydra-pay.cabal
+++ b/hydra-pay/hydra-pay.cabal
@@ -42,6 +42,7 @@ library
     , typed-process
     , websockets
     , which
+    , async
 
   default-extensions:
     ConstraintKinds

--- a/hydra-pay/hydra-pay.cabal
+++ b/hydra-pay/hydra-pay.cabal
@@ -12,6 +12,7 @@ library
     , beam-core
     , beam-postgres
     , bytestring
+    , bytestring-aeson-orphans
     , cardano-api
     , cardano-transaction
     , containers

--- a/hydra-pay/src/HydraPay.hs
+++ b/hydra-pay/src/HydraPay.hs
@@ -31,7 +31,6 @@ import HydraPay.Database.Workers (RefundRequest(..))
 import HydraPay.Proxy
 import HydraPay.Transaction
 import qualified HydraPay.Database as DB
-import HydraPay.PaymentChannel.Postgres (getExpiredPaymentChannels)
 import HydraPay.PaymentChannel
 
 import Control.Concurrent (threadDelay)
@@ -42,8 +41,6 @@ import qualified Data.ByteString.Char8 as B8
 import Data.String
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-import Data.Time (UTCTime)
 
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS

--- a/hydra-pay/src/HydraPay.hs
+++ b/hydra-pay/src/HydraPay.hs
@@ -143,7 +143,7 @@ waitForTxInput state txin = runExceptT $ do
   case exists of
     True -> pure ()
     False -> do
-      liftIO $ threadDelay 100000
+      liftIO $ threadDelay 500000
       ExceptT $ waitForTxInput state txin
 
 payFuelTo :: Api.AddressAny -> FilePath -> Api.AddressAny -> Int32 -> Tx ()

--- a/hydra-pay/src/HydraPay/Cardano/Cli.hs
+++ b/hydra-pay/src/HydraPay/Cardano/Cli.hs
@@ -2,6 +2,7 @@
 
 module HydraPay.Cardano.Cli where
 
+import Debug.Trace
 import HydraPay.Types
 import HydraPay.Utils
 import HydraPay.Cardano.Node
@@ -90,7 +91,7 @@ runCardanoCli a command = do
     CardanoCliCommand_QueryUTXOs _ -> do
       fmap (first T.pack) $ runExceptT $ do
         str <- ExceptT $ eitherReadProcess cp
-        ExceptT $ pure $ Aeson.eitherDecode $ LBS.fromStrict $ B8.pack str
+        ExceptT $ pure $ Aeson.eitherDecode $ LBS.fromStrict $ B8.pack $ trace ("This was " <> str) str
 
     CardanoCliCommand_BuildAddress _ -> do
       fmap (first T.pack) $ runExceptT $ do
@@ -175,7 +176,7 @@ makeCliProcess ni command =
         base [ "query"
              , "utxo"
              , "--address"
-             , T.unpack $ Api.serialiseAddress addr
+             , trace ("The address was " <> T.unpack (Api.serialiseAddress addr)) (T.unpack $ Api.serialiseAddress addr)
              , "--testnet-magic"
              , magic
              , "--out-file"

--- a/hydra-pay/src/HydraPay/Cardano/Hydra.hs
+++ b/hydra-pay/src/HydraPay/Cardano/Hydra.hs
@@ -135,10 +135,10 @@ commsThreadIsHeadStateReporter cfg =
   -- NOTE currently we just make the first node the state reported
   cfg ^. commsThreadConfig_hydraNodeConfig . hydraNodeConfig_nodeId . to (==1)
 
--- | Transaction ID on preview from the Hydra 9.0 release
--- https://github.com/input-output-hk/hydra/releases/tag/0.9.0
+-- | Transaction ID on preview from the Hydra 0.10.0 release
+-- https://github.com/input-output-hk/hydra/releases/tag/0.10.0
 previewScriptTxId :: TxId
-previewScriptTxId = TxId "74b587d08d12aa679bdfeb3eaa57d698e426045dd529d4130d7d8ca0c18d54b0"
+previewScriptTxId = TxId "d237926e174a2ca386174a5810d30f0ca6db352219dd7eacdc7d5969ae75d58f"
 
 loopbackAddress :: String
 loopbackAddress = "127.0.0.1"

--- a/hydra-pay/src/HydraPay/Cardano/Hydra.hs
+++ b/hydra-pay/src/HydraPay/Cardano/Hydra.hs
@@ -271,6 +271,7 @@ runHydraHead a headId configs = liftIO $ do
       case result of
         Left (SomeException e) -> log $ "Hydra node encountered an error: " <> T.pack (show e)
         Right ec -> log $ "Hydra node exited with: " <> T.pack (show ec)
+      threadDelay 250000
     pure $ Map.singleton (config ^. hydraNodeConfig_for) $ HydraNode (config ^. hydraNodeConfig_apiPort) process communicationThread nodeStatus requests queue nodeRunner
   pure $ RunningHydraHead headStatus (foldOf each handles)
 
@@ -311,8 +312,9 @@ spawnHydraNodeApiConnectionThread a headId cfg@(CommsThreadConfig config headSta
             Left err -> do
               logInfo a loggerName $ "Invalid message received: " <> tShow payload <> " " <> T.pack err
         case result of
-          Left err@(SomeException _) ->
+          Left err@(SomeException _) -> do
             logInfo a loggerName $ "Message Handler failed: " <> tShow err
+            threadDelay 250000
           Right _ ->
             pure ()
   where

--- a/hydra-pay/src/HydraPay/Cardano/Hydra.hs
+++ b/hydra-pay/src/HydraPay/Cardano/Hydra.hs
@@ -31,7 +31,7 @@ import HydraPay.Cardano.Cli
 import HydraPay.Cardano.Hydra.ChainConfig (HydraChainConfig(..))
 import HydraPay.Cardano.Node
 import HydraPay.PaymentChannel (PaymentChannelStatus(..))
-import HydraPay.PaymentChannel.Postgres (initPaymentChannelQ)
+import HydraPay.PaymentChannel.Postgres (updatePaymentChannelStatusQ)
 import HydraPay.PortRange
 import HydraPay.Cardano.Hydra.RunningHead
 import HydraPay.Cardano.Hydra.Api hiding (headId, headStatus)
@@ -298,7 +298,7 @@ spawnHydraNodeApiConnectionThread a headId cfg@(CommsThreadConfig config headSta
         when (commsThreadIsHeadStateReporter cfg) $ do
           logInfo a loggerName "Head is open"
           atomically $ writeTVar headStatus $ HydraHead_Open
-          Db.runBeam a $ initPaymentChannelQ headId
+          Db.runBeam a $ updatePaymentChannelStatusQ headId PaymentChannelStatus_Open
       HeadIsClosed hid _ deadline -> do
         when isReporter $ do
           logInfo a loggerName $ "Head is closed: " <> tShow hid <> "\ntimeout: " <> tShow deadline

--- a/hydra-pay/src/HydraPay/Cardano/Hydra.hs
+++ b/hydra-pay/src/HydraPay/Cardano/Hydra.hs
@@ -32,7 +32,7 @@ import HydraPay.Cardano.Hydra.ChainConfig (HydraChainConfig(..))
 import HydraPay.Cardano.Node
 import HydraPay.PortRange
 import HydraPay.Cardano.Hydra.RunningHead
-import HydraPay.Cardano.Hydra.Api hiding (headId)
+import HydraPay.Cardano.Hydra.Api hiding (headId, headStatus)
 import HydraPay.Transaction
 import qualified HydraPay.Database as Db
 
@@ -281,7 +281,7 @@ spawnHydraNodeApiConnectionThread a cfg@(CommsThreadConfig config headStatus nod
   where
     -- Update hydra-pay state based on hydra node responses
     handleHydraNodeApiResponse loggerName isReporter = \case
-      Greetings _ ->
+      Greetings {} ->
         atomically $ writeTVar nodeStatus $ HydraNodeStatus_Replayed
       PeerConnected _ -> do
         logInfo a loggerName "Hydra Node ready"

--- a/hydra-pay/src/HydraPay/Cardano/Hydra.hs
+++ b/hydra-pay/src/HydraPay/Cardano/Hydra.hs
@@ -617,7 +617,7 @@ activeHydraHeads = do
   runSelectReturningList $ select $ do
     heads_ <- all_ (Db.db ^. Db.db_heads)
     paymentChan_ <- join_ (Db.db ^. Db.db_paymentChannels) (\paymentChan -> (paymentChan ^. Db.paymentChannel_head) `references_` heads_)
-    guard_ (paymentChan_ ^. Db.paymentChannel_open)
+    guard_ (paymentChan_ ^. Db.paymentChannel_open /=. val_ (Just False))
     pure $ heads_
 
 spinUpHead :: (MonadIO m, MonadBeam Postgres m, MonadBeamInsertReturning Postgres m, Db.HasDbConnectionPool a, HasLogger a, HasNodeInfo a, HasPortRange a, HasHydraHeadManager a) => a -> Int32 -> m (Either Text ())

--- a/hydra-pay/src/HydraPay/Cardano/Hydra.hs
+++ b/hydra-pay/src/HydraPay/Cardano/Hydra.hs
@@ -489,7 +489,7 @@ mkHydraNodeProc cfg = do
      , cfg ^. hydraNodeConfig_ledgerGenesis
      , "--ledger-protocol-parameters"
      , cfg ^. hydraNodeConfig_ledgerProtocolParams
-     , "--network-id"
+     , "--testnet-magic"
      , cfg ^. hydraNodeConfig_magic . to show
      , "--node-socket"
      , cfg ^. hydraNodeConfig_cardanoNodeSocket

--- a/hydra-pay/src/HydraPay/Database.hs
+++ b/hydra-pay/src/HydraPay/Database.hs
@@ -38,9 +38,9 @@ data HydraHeadsT f = HydraHead
 instance Beamable HydraHeadsT
 
 instance Table HydraHeadsT where
-  data PrimaryKey HydraHeadsT f = HeadID (C f (SqlSerial Int32))
+  data PrimaryKey HydraHeadsT f = HeadId (C f (SqlSerial Int32))
     deriving (Generic)
-  primaryKey = HeadID . _hydraHead_id
+  primaryKey = HeadId . _hydraHead_id
 
 instance Beamable (PrimaryKey HydraHeadsT)
 
@@ -61,9 +61,9 @@ data ProxiesT f = ProxyInfo
 instance Beamable ProxiesT
 
 instance Table ProxiesT where
-  data PrimaryKey ProxiesT f = ProxyID (C f (SqlSerial Int32))
+  data PrimaryKey ProxiesT f = ProxyId (C f (SqlSerial Int32))
     deriving (Generic)
-  primaryKey = ProxyID . _proxy_id
+  primaryKey = ProxyId . _proxy_id
 
 instance Beamable (PrimaryKey ProxiesT)
 
@@ -99,9 +99,9 @@ data PaymentChannelsT f = PaymentChannel
 instance Beamable PaymentChannelsT
 
 instance Table PaymentChannelsT where
-  data PrimaryKey PaymentChannelsT f = PaymentChannelID (C f (SqlSerial Int32))
+  data PrimaryKey PaymentChannelsT f = PaymentChannelId (C f (SqlSerial Int32))
     deriving (Generic)
-  primaryKey = PaymentChannelID . _paymentChannel_id
+  primaryKey = PaymentChannelId . _paymentChannel_id
 
 instance Beamable (PrimaryKey PaymentChannelsT)
 
@@ -119,17 +119,35 @@ data TransactionsT f = Transaction
 instance Beamable TransactionsT
 
 instance Table TransactionsT where
-  data PrimaryKey TransactionsT f = TransactionID (C f (SqlSerial Int32))
+  data PrimaryKey TransactionsT f = TransactionId (C f (SqlSerial Int32))
     deriving (Generic)
-  primaryKey = TransactionID . _transaction_id
+  primaryKey = TransactionId . _transaction_id
 
 instance Beamable (PrimaryKey TransactionsT)
 
 type Transaction = TransactionsT Identity
 
+-- | Associates a given Proxy Address with a Head and therefore a node.
+data ProxyHeadT f = ProxyHead
+  { _proxyHead_id :: C f (SqlSerial Int32)
+  , _proxyHead_proxy :: PrimaryKey ProxiesT f
+  , _proxyHead_head :: PrimaryKey HydraHeadsT f
+  }
+  deriving (Generic)
+
+instance Beamable ProxyHeadT
+
+instance Table ProxyHeadT where
+  data PrimaryKey ProxyHeadT f = ProxyHeadId (C f (SqlSerial Int32))
+    deriving (Generic)
+  primaryKey = ProxyHeadId . _proxyHead_id
+
+instance Beamable (PrimaryKey ProxyHeadT)
+
 data Db f = Db
   { _db_proxies :: f (TableEntity ProxiesT)
   , _db_heads :: f (TableEntity HydraHeadsT)
+  , _db_proxyHead :: f (TableEntity ProxyHeadT)
   , _db_paymentChannels :: f (TableEntity PaymentChannelsT)
   , _db_transactions :: f (TableEntity TransactionsT)
   , _db_paymentChanTask :: f (TableEntity PaymentChannelTaskT)
@@ -144,6 +162,7 @@ class HasDbConnectionPool a where
 instance HasDbConnectionPool (Pool Connection) where
   dbConnectionPool = id
 
+makeLenses ''ProxyHeadT
 makeLenses ''PaymentChannelsT
 makeLenses ''TransactionsT
 makeLenses ''HydraHeadsT

--- a/hydra-pay/src/HydraPay/Database.hs
+++ b/hydra-pay/src/HydraPay/Database.hs
@@ -69,7 +69,6 @@ instance Beamable (PrimaryKey ProxiesT)
 
 type ProxyInfo = ProxiesT Identity
 
-
 instance BA.HasColumnType PaymentChannelStatus where
   defaultColumnType = const $ Beam.defaultColumnType $ Proxy @Text
 

--- a/hydra-pay/src/HydraPay/Database.hs
+++ b/hydra-pay/src/HydraPay/Database.hs
@@ -63,6 +63,7 @@ data PaymentChannelsT f = PaymentChannel
   { _paymentChannel_id :: C f (SqlSerial Int32)
   , _paymentChannel_name :: C f Text
   , _paymentChannel_head :: PrimaryKey HydraHeadsT f
+  , _paymentChannel_createdAt :: C f UTCTime
   , _paymentChannel_expiry :: C f UTCTime
   , _paymentChannel_open :: C f Bool
   }

--- a/hydra-pay/src/HydraPay/Database.hs
+++ b/hydra-pay/src/HydraPay/Database.hs
@@ -92,6 +92,7 @@ data PaymentChannelsT f = PaymentChannel
   , _paymentChannel_createdAt :: C f UTCTime
   , _paymentChannel_expiry :: C f UTCTime
   , _paymentChannel_status :: C f PaymentChannelStatus
+  , _paymentChannel_commits :: C f Int32
   }
   deriving (Generic)
 

--- a/hydra-pay/src/HydraPay/Database.hs
+++ b/hydra-pay/src/HydraPay/Database.hs
@@ -48,7 +48,8 @@ type HydraHead = HydraHeadsT Identity
 type HeadId = PrimaryKey HydraHeadsT Identity
 
 data ProxiesT f = ProxyInfo
-   { _proxy_chainAddress :: C f Text
+   { _proxy_id :: C f (SqlSerial Int32)
+   , _proxy_chainAddress :: C f Text
    , _proxy_hydraAddress :: C f Text
    , _proxy_verificationKeyPath :: C f Text
    , _proxy_signingKeyPath :: C f Text
@@ -60,9 +61,9 @@ data ProxiesT f = ProxyInfo
 instance Beamable ProxiesT
 
 instance Table ProxiesT where
-  data PrimaryKey ProxiesT f = ProxyID (C f Text)
+  data PrimaryKey ProxiesT f = ProxyID (C f (SqlSerial Int32))
     deriving (Generic)
-  primaryKey = ProxyID . _proxy_chainAddress
+  primaryKey = ProxyID . _proxy_id
 
 instance Beamable (PrimaryKey ProxiesT)
 

--- a/hydra-pay/src/HydraPay/Database.hs
+++ b/hydra-pay/src/HydraPay/Database.hs
@@ -131,7 +131,7 @@ data Db f = Db
   , _db_heads :: f (TableEntity HydraHeadsT)
   , _db_paymentChannels :: f (TableEntity PaymentChannelsT)
   , _db_transactions :: f (TableEntity TransactionsT)
-  , _db_openChanTask :: f (TableEntity OpenChannelTaskT)
+  , _db_paymentChanTask :: f (TableEntity PaymentChannelTaskT)
   }
   deriving (Generic)
 

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -16,48 +16,49 @@ import Database.Beam.Postgres
 import Database.Beam.Postgres.Syntax (PgValueSyntax)
 
 
-data OpenChannelReq = OpenChannelReq
-  { _openChannelReq_headId :: Int32
+data PaymentChannelReq
+  = PaymentChannelReq_Init Int32
   -- ^ The head id used to find the data required on the db to fullfill the Open
   -- Channel request.
-  }
+  | PaymentChannelReq_Accept Int32
+  | PaymentChannelReq_Close Int32
   deriving Generic
 
-instance FromJSON OpenChannelReq
-instance ToJSON OpenChannelReq
+instance FromJSON PaymentChannelReq
+instance ToJSON PaymentChannelReq
 
-instance Beam.HasColumnType OpenChannelReq where
-  defaultColumnType = const $ Beam.defaultColumnType $ Proxy @(PgJSON OpenChannelReq)
+instance Beam.HasColumnType PaymentChannelReq where
+  defaultColumnType = const $ Beam.defaultColumnType $ Proxy @(PgJSON PaymentChannelReq)
 
-instance FromBackendRow Postgres OpenChannelReq where
+instance FromBackendRow Postgres PaymentChannelReq where
   fromBackendRow = (\(PgJSON x) -> x) <$> fromBackendRow
 
-instance HasSqlValueSyntax PgValueSyntax OpenChannelReq where
+instance HasSqlValueSyntax PgValueSyntax PaymentChannelReq where
   sqlValueSyntax = sqlValueSyntax . PgJSON
 
 
-data OpenChannelTaskT f = OpenChannelTask
-  { _openChannelTask_id :: Columnar f (SqlSerial Int32)
-  , _openChannelTask_checkedOutBy :: Columnar f (Maybe Text)
-  , _openChannelTask_payload :: Columnar f OpenChannelReq
-  , _openChannelTask_status :: Columnar f (Maybe Bool)
-  , _openChannelTask_finished :: Columnar f Bool
-  , _openChannelTask_time :: Columnar f UTCTime
+data PaymentChannelTaskT f = PaymentChannelTask
+  { _paymentChannelTask_id :: Columnar f (SqlSerial Int32)
+  , _paymentChannelTask_checkedOutBy :: Columnar f (Maybe Text)
+  , _paymentChannelTask_payload :: Columnar f PaymentChannelReq
+  , _paymentChannelTask_status :: Columnar f (Maybe Bool)
+  , _paymentChannelTask_finished :: Columnar f Bool
+  , _paymentChannelTask_time :: Columnar f UTCTime
   }
   deriving Generic
 
-type OpenChannelTask = OpenChannelTaskT Identity
-type OpenChannelTaskId = PrimaryKey OpenChannelTaskT Identity
+type PaymentChannelTask = PaymentChannelTaskT Identity
+type PaymentChannelTaskId = PrimaryKey PaymentChannelTaskT Identity
 
-instance Table OpenChannelTaskT where
-  newtype PrimaryKey OpenChannelTaskT f = OpenChannelTaskId
-    { unOpenChannelTaskId :: Columnar f (SqlSerial Int32)
+instance Table PaymentChannelTaskT where
+  newtype PrimaryKey PaymentChannelTaskT f = PaymentChannelTaskId
+    { unPaymentChannelTaskId :: Columnar f (SqlSerial Int32)
     } deriving (Generic)
-  primaryKey = OpenChannelTaskId . _openChannelTask_id
+  primaryKey = PaymentChannelTaskId . _paymentChannelTask_id
 
-instance Beamable OpenChannelTaskT
-instance Beamable (PrimaryKey OpenChannelTaskT)
+instance Beamable PaymentChannelTaskT
+instance Beamable (PrimaryKey PaymentChannelTaskT)
 
 fmap concat $ traverse makeLenses
-  [ ''OpenChannelTaskT
+  [ ''PaymentChannelTaskT
   ]

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -16,7 +16,21 @@ import qualified Database.Beam.AutoMigrate as Beam
 import Database.Beam.Backend
 import Database.Beam.Postgres
 import Database.Beam.Postgres.Syntax (PgValueSyntax)
+import qualified Cardano.Api as Api
+import qualified Cardano.Api.Shelley as Api
 
+data RefundRequest = RefundRequest
+  { _refundRequest_hydraHead :: Int32
+  , _refundRequest_hydraAddress :: Text
+  , _refundRequest_signingKeyPath :: FilePath
+  , _refundRequest_chainAddress :: Text
+  , _refundRequest_amount :: Int32
+  , _refundRequest_protocolParams :: Text
+  }
+  deriving Generic
+
+instance FromJSON RefundRequest
+instance ToJSON RefundRequest
 
 data PaymentChannelReq
   = PaymentChannelReq_Init Int32 SignedTx
@@ -24,7 +38,7 @@ data PaymentChannelReq
   -- Channel request.
   | PaymentChannelReq_Accept Int32 SignedTx
   | PaymentChannelReq_Close Int32 Text
-  | PaymentChannelReq_InitiatorRefund UTCTime
+  | PaymentChannelReq_InitiatorRefund RefundRequest
   deriving Generic
 
 type SignedTx = ByteString
@@ -40,7 +54,6 @@ instance FromBackendRow Postgres PaymentChannelReq where
 
 instance HasSqlValueSyntax PgValueSyntax PaymentChannelReq where
   sqlValueSyntax = sqlValueSyntax . PgJSON
-
 
 data PaymentChannelTaskT f = PaymentChannelTask
   { _paymentChannelTask_id :: Columnar f (SqlSerial Int32)

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -1,0 +1,74 @@
+-- | Tracking Hydra Tasks from a database.
+
+{-# LANGUAGE TemplateHaskell #-}
+module HydraPay.Database.Workers where
+
+import Control.Lens (iso, makeLenses)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Int (Int32)
+import Data.Pool
+import Data.Proxy
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+import Data.Time (UTCTime)
+import Database.Beam
+import qualified Database.Beam.AutoMigrate as Beam
+import Database.Beam.Backend
+import Database.Beam.Backend.SQL
+import Database.Beam.Backend.SQL.BeamExtensions
+import Database.Beam.Postgres
+import Database.Beam.Postgres.Syntax (PgValueSyntax, PgExpressionSyntax(..), emit)
+import Database.PostgreSQL.Simple.FromField
+
+import Obelisk.Route
+import Rhyolite.DB.Beam.Types
+import Rhyolite.Task.Beam
+import Rhyolite.Task.Beam.Worker
+
+
+data OpenChannelReq = OpenChannelReq
+  { _openChannelReq_headId :: Int32
+  -- ^ The head id used to find the data required on the db to fullfill the Open
+  -- Channel request.
+  }
+  deriving Generic
+
+instance FromJSON OpenChannelReq
+instance ToJSON OpenChannelReq
+
+instance Beam.HasColumnType OpenChannelReq where
+  defaultColumnType = const $ Beam.defaultColumnType $ Proxy @(PgJSON OpenChannelReq)
+
+instance FromBackendRow Postgres OpenChannelReq where
+  fromBackendRow = (\(PgJSON x) -> x) <$> fromBackendRow
+
+instance HasSqlValueSyntax PgValueSyntax OpenChannelReq where
+  sqlValueSyntax = sqlValueSyntax . PgJSON
+
+
+data OpenChannelTaskT f = OpenChannelTask
+  { _openChannelTask_id :: Columnar f (SqlSerial Int32)
+  , _openChannelTask_checkedOutBy :: Columnar f (Maybe Text)
+  , _openChannelTask_payload :: Columnar f OpenChannelReq
+  , _openChannelTask_status :: Columnar f (Maybe Bool)
+  , _openChannelTask_finished :: Columnar f Bool
+  , _openChannelTask_time :: Columnar f UTCTime
+  }
+  deriving Generic
+
+type OpenChannelTask = OpenChannelTaskT Identity
+type OpenChannelTaskId = PrimaryKey OpenChannelTaskT Identity
+
+instance Table OpenChannelTaskT where
+  newtype PrimaryKey OpenChannelTaskT f = OpenChannelTaskId
+    { unOpenChannelTaskId :: Columnar f (SqlSerial Int32)
+    } deriving (Generic)
+  primaryKey = OpenChannelTaskId . _openChannelTask_id
+
+instance Beamable OpenChannelTaskT
+instance Beamable (PrimaryKey OpenChannelTaskT)
+
+fmap concat $ traverse makeLenses
+  [ ''OpenChannelTaskT
+  ]

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -3,8 +3,10 @@
 {-# LANGUAGE TemplateHaskell #-}
 module HydraPay.Database.Workers where
 
+import ByteString.Aeson.Orphans ()
 import Control.Lens (makeLenses)
 import Data.Aeson (FromJSON, ToJSON)
+import Data.ByteString (ByteString)
 import Data.Int (Int32)
 import Data.Proxy
 import Data.Text (Text)
@@ -17,12 +19,14 @@ import Database.Beam.Postgres.Syntax (PgValueSyntax)
 
 
 data PaymentChannelReq
-  = PaymentChannelReq_Init Int32
+  = PaymentChannelReq_Init Int32 SignedTx
   -- ^ The head id used to find the data required on the db to fullfill the Open
   -- Channel request.
-  | PaymentChannelReq_Accept Int32
+  | PaymentChannelReq_Accept Int32 SignedTx
   | PaymentChannelReq_Close Int32 Text
   deriving Generic
+
+type SignedTx = ByteString
 
 instance FromJSON PaymentChannelReq
 instance ToJSON PaymentChannelReq

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -24,6 +24,7 @@ data PaymentChannelReq
   -- Channel request.
   | PaymentChannelReq_Accept Int32 SignedTx
   | PaymentChannelReq_Close Int32 Text
+  | PaymentChannelReq_InitiatorRefund UTCTime
   deriving Generic
 
 type SignedTx = ByteString

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -48,6 +48,7 @@ data PaymentChannelReq
   | PaymentChannelReq_Commit Int32 Text Api.Lovelace
   | PaymentChannelReq_Fanout Int32
   | PaymentChannelReq_Cleanup Int32
+  | PaymentChannelReq_Poke
   deriving Generic
 
 data FundRequest = FundRequest

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -40,7 +40,14 @@ data PaymentChannelReq
   | PaymentChannelReq_Accept Int32
   | PaymentChannelReq_Close Int32 Text
   | PaymentChannelReq_InitiatorRefund RefundRequest
-  | PaymentChannelReq_Bank [FundRequest] -- Proxy ids to fund
+  | PaymentChannelReq_Fund Int32 [FundRequest] -- Proxy ids to fund
+  | PaymentChannelReq_Join Int32 Text Api.Lovelace
+  | PaymentChannelReq_RetryInit Int32
+  | PaymentChannelReq_RetryClose Int32 Text
+  | PaymentChannelReq_SpinUpHead Int32
+  | PaymentChannelReq_Commit Int32 Text Api.Lovelace
+  | PaymentChannelReq_Fanout Int32
+  | PaymentChannelReq_Cleanup Int32
   deriving Generic
 
 data FundRequest = FundRequest

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -33,21 +33,11 @@ instance FromJSON RefundRequest
 instance ToJSON RefundRequest
 
 data PaymentChannelReq
-  = PaymentChannelReq_Init Int32 Text
-  -- ^ The head id used to find the data required on the db to fullfill the Open
-  -- Channel request.
-  | PaymentChannelReq_Accept Int32
-  | PaymentChannelReq_Close Int32 Text
-  | PaymentChannelReq_InitiatorRefund RefundRequest
-  | PaymentChannelReq_Fund Int32 [FundRequest] -- Proxy ids to fund
+  = PaymentChannelReq_InitiatorRefund RefundRequest
+  | PaymentChannelReq_Fund Int32 [FundRequest]
   | PaymentChannelReq_Join Int32 Text Api.Lovelace
-  | PaymentChannelReq_RetryInit Int32
-  | PaymentChannelReq_RetryClose Int32 Text
   | PaymentChannelReq_SpinUpHead Int32
-  | PaymentChannelReq_Commit Int32 Text Api.Lovelace
-  | PaymentChannelReq_Fanout Int32
   | PaymentChannelReq_Cleanup Int32
-  | PaymentChannelReq_Poke
   deriving Generic
 
 data FundRequest = FundRequest

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -3,28 +3,17 @@
 {-# LANGUAGE TemplateHaskell #-}
 module HydraPay.Database.Workers where
 
-import Control.Lens (iso, makeLenses)
+import Control.Lens (makeLenses)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Int (Int32)
-import Data.Pool
 import Data.Proxy
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as LT
 import Data.Time (UTCTime)
 import Database.Beam
 import qualified Database.Beam.AutoMigrate as Beam
 import Database.Beam.Backend
-import Database.Beam.Backend.SQL
-import Database.Beam.Backend.SQL.BeamExtensions
 import Database.Beam.Postgres
-import Database.Beam.Postgres.Syntax (PgValueSyntax, PgExpressionSyntax(..), emit)
-import Database.PostgreSQL.Simple.FromField
-
-import Obelisk.Route
-import Rhyolite.DB.Beam.Types
-import Rhyolite.Task.Beam
-import Rhyolite.Task.Beam.Worker
+import Database.Beam.Postgres.Syntax (PgValueSyntax)
 
 
 data OpenChannelReq = OpenChannelReq

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -34,7 +34,7 @@ instance FromJSON RefundRequest
 instance ToJSON RefundRequest
 
 data PaymentChannelReq
-  = PaymentChannelReq_Init Int32
+  = PaymentChannelReq_Init Int32 Text
   -- ^ The head id used to find the data required on the db to fullfill the Open
   -- Channel request.
   | PaymentChannelReq_Accept Int32

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -21,7 +21,7 @@ data PaymentChannelReq
   -- ^ The head id used to find the data required on the db to fullfill the Open
   -- Channel request.
   | PaymentChannelReq_Accept Int32
-  | PaymentChannelReq_Close Int32
+  | PaymentChannelReq_Close Int32 Text
   deriving Generic
 
 instance FromJSON PaymentChannelReq

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -18,7 +18,6 @@ import Database.Beam.Backend
 import Database.Beam.Postgres
 import Database.Beam.Postgres.Syntax (PgValueSyntax)
 import qualified Cardano.Api as Api
-import qualified Cardano.Api.Shelley as Api
 
 data RefundRequest = RefundRequest
   { _refundRequest_hydraHead :: Int32

--- a/hydra-pay/src/HydraPay/Database/Workers.hs
+++ b/hydra-pay/src/HydraPay/Database/Workers.hs
@@ -37,8 +37,7 @@ data PaymentChannelReq
   = PaymentChannelReq_Init Int32
   -- ^ The head id used to find the data required on the db to fullfill the Open
   -- Channel request.
-  | PaymentChannelReq_Fund Int32 Int32
-  | PaymentChannelReq_Accept Int32 SignedTx
+  | PaymentChannelReq_Accept Int32
   | PaymentChannelReq_Close Int32 Text
   | PaymentChannelReq_InitiatorRefund RefundRequest
   | PaymentChannelReq_Bank [FundRequest] -- Proxy ids to fund

--- a/hydra-pay/src/HydraPay/PaymentChannel/Postgres.hs
+++ b/hydra-pay/src/HydraPay/PaymentChannel/Postgres.hs
@@ -242,13 +242,13 @@ createPaymentChannel a (PaymentChannelConfig name first second amount chain) = d
     secondText = Api.serialiseAddress second
 
 closePaymentChannelQ :: (MonadBeam Postgres m) => Int32 -> m ()
-closePaymentChannelQ headId = do
-  runUpdate $ update (Db.db ^. Db.db_paymentChannels)
-    (\channel -> channel ^. Db.paymentChannel_status <-. val_ PaymentChannelStatus_Closed)
-    (\channel -> channel ^. Db.paymentChannel_head ==. val_ (Db.HeadID (SqlSerial headId)))
+closePaymentChannelQ headId = updatePaymentChannelStatusQ headId PaymentChannelStatus_Closed
 
-initPaymentChannelQ :: (MonadBeam Postgres m) => Int32 -> m ()
-initPaymentChannelQ headId = do
+closingPaymentChannelQ :: (MonadBeam Postgres m) => Int32 -> m ()
+closingPaymentChannelQ headId = updatePaymentChannelStatusQ headId PaymentChannelStatus_Closing
+
+updatePaymentChannelStatusQ :: MonadBeam Postgres m => Int32 -> PaymentChannelStatus -> m ()
+updatePaymentChannelStatusQ headId status = do
   runUpdate $ update (Db.db ^. Db.db_paymentChannels)
-    (\channel -> channel ^. Db.paymentChannel_status <-. val_ PaymentChannelStatus_Initialized)
+    (\channel -> channel ^. Db.paymentChannel_status <-. val_ status)
     (\channel -> channel ^. Db.paymentChannel_head ==. val_ (Db.HeadID (SqlSerial headId)))

--- a/hydra-pay/src/HydraPay/PaymentChannel/Postgres.hs
+++ b/hydra-pay/src/HydraPay/PaymentChannel/Postgres.hs
@@ -206,13 +206,13 @@ sendAdaInChannel hid you amount = runExceptT $ do
 
 getPaymentChannelHeadId :: (MonadBeam Postgres m, MonadFail m) => Int32 -> m Int32
 getPaymentChannelHeadId pcId = do
-  Just paymentChannel <- runSelectReturningOne (lookup_ (Db.db ^. Db.db_paymentChannels) (Db.PaymentChannelID $ SqlSerial pcId))
-  let Db.HeadID (SqlSerial hid) = Db._paymentChannel_head paymentChannel
+  Just paymentChannel <- runSelectReturningOne (lookup_ (Db.db ^. Db.db_paymentChannels) (Db.PaymentChannelId $ SqlSerial pcId))
+  let Db.HeadId (SqlSerial hid) = Db._paymentChannel_head paymentChannel
   pure hid
 
 getHydraHead :: (MonadBeam Postgres m, MonadFail m) => Int32 -> m Db.HydraHead
 getHydraHead headId = do
-  Just hydraHead <- runSelectReturningOne (lookup_ (Db.db ^. Db.db_heads) (Db.HeadID $ SqlSerial headId))
+  Just hydraHead <- runSelectReturningOne (lookup_ (Db.db ^. Db.db_heads) (Db.HeadId $ SqlSerial headId))
   pure hydraHead
 
 joinPaymentChannel :: (MonadBeam Postgres m) => Int32 -> Int32 -> m ()
@@ -270,4 +270,4 @@ updatePaymentChannelStatusQ :: MonadBeam Postgres m => Int32 -> PaymentChannelSt
 updatePaymentChannelStatusQ headId status = do
   runUpdate $ update (Db.db ^. Db.db_paymentChannels)
     (\channel -> channel ^. Db.paymentChannel_status <-. val_ status)
-    (\channel -> channel ^. Db.paymentChannel_head ==. val_ (Db.HeadID (SqlSerial headId)))
+    (\channel -> channel ^. Db.paymentChannel_head ==. val_ (Db.HeadId (SqlSerial headId)))

--- a/hydra-pay/src/HydraPay/PaymentChannel/Postgres.hs
+++ b/hydra-pay/src/HydraPay/PaymentChannel/Postgres.hs
@@ -271,3 +271,11 @@ updatePaymentChannelStatusQ headId status = do
   runUpdate $ update (Db.db ^. Db.db_paymentChannels)
     (\channel -> channel ^. Db.paymentChannel_status <-. val_ status)
     (\channel -> channel ^. Db.paymentChannel_head ==. val_ (Db.HeadId (SqlSerial headId)))
+
+getPaymentChannelStatusQ :: MonadBeam Postgres m => Int32 -> m PaymentChannelStatus
+getPaymentChannelStatusQ headId = do
+  mChan <- runSelectReturningOne $ select $ do
+    chan <- all_ $ Db.db ^. Db.db_paymentChannels
+    guard_ (chan ^. Db.paymentChannel_head ==. val_ (Db.HeadId (SqlSerial headId)))
+    pure chan
+  pure $ maybe PaymentChannelStatus_Unknown Db._paymentChannel_status mChan

--- a/hydra-pay/src/HydraPay/PaymentChannel/Postgres.hs
+++ b/hydra-pay/src/HydraPay/PaymentChannel/Postgres.hs
@@ -55,11 +55,13 @@ getPaymentChannelInfo a me pid = do
 dbPaymentChannelToInfo :: Api.AddressAny -> Db.HydraHead -> Db.PaymentChannel -> PaymentChannelInfo
 dbPaymentChannelToInfo addr hh pc =
   PaymentChannelInfo
-  (pc ^. Db.paymentChannel_id . to unSerial)
-  (pc ^. Db.paymentChannel_name)
-  other
-  status
-  isInitiator
+    { _paymentChannelInfo_id = pc ^. Db.paymentChannel_id . to unSerial
+    , _paymentChannelInfo_name = pc ^. Db.paymentChannel_name
+    , _paymentChannelInfo_createdAt = pc ^. Db.paymentChannel_createdAt
+    , _paymentChannelInfo_other = other
+    , _paymentChannelInfo_status = status
+    , _paymentChannelInfo_initiator = isInitiator
+    }
   where
     status =
       case hh ^. Db.hydraHead_secondBalance of
@@ -227,6 +229,7 @@ createPaymentChannel a (PaymentChannelConfig name first second amount chain) = d
                           default_
                           (val_ name)
                           (val_ $ primaryKey newHead)
+                          current_timestamp_
                           (addOneDayInterval_ current_timestamp_)
                           (val_ True)
                         ]

--- a/hydra-pay/src/HydraPay/Proxy.hs
+++ b/hydra-pay/src/HydraPay/Proxy.hs
@@ -56,13 +56,14 @@ addProxyInfo :: MonadBeamInsertReturning Postgres m => Api.AddressAny -> ProxyIn
 addProxyInfo addr pinfo = do
   result <- runInsertReturningList
     $ insertOnConflict (DB.db ^. DB.db_proxies)
-    (insertValues [ DB.ProxyInfo
-                    (Api.serialiseAddress addr)
-                    (pinfo ^. proxyInfo_address . to (Api.serialiseAddress))
-                    (pinfo ^. proxyInfo_verificationKey . to (T.pack))
-                    (pinfo ^. proxyInfo_signingKey . to (T.pack))
-                    (pinfo ^. proxyInfo_hydraVerificationKey . to (T.pack))
-                    (pinfo ^. proxyInfo_hydraSigningKey . to (T.pack))
+    (insertExpressions [ DB.ProxyInfo
+                         default_
+                         (val_ $ Api.serialiseAddress addr)
+                         (val_ $ pinfo ^. proxyInfo_address . to (Api.serialiseAddress))
+                         (val_ $ pinfo ^. proxyInfo_verificationKey . to (T.pack))
+                         (val_ $ pinfo ^. proxyInfo_signingKey . to (T.pack))
+                         (val_ $ pinfo ^. proxyInfo_hydraVerificationKey . to (T.pack))
+                         (val_ $ pinfo ^. proxyInfo_hydraSigningKey . to (T.pack))
                   ])
     -- If somehow we had someone insert before we did, we should get the information back out and use that
     anyConflict onConflictDoNothing

--- a/hydra-pay/src/HydraPay/Proxy.hs
+++ b/hydra-pay/src/HydraPay/Proxy.hs
@@ -99,7 +99,7 @@ queryProxyInfo a headId addr = do
     Nothing -> do
       runExceptT $ do
         let
-          prefix = T.unpack $ T.takeEnd 8 $ Api.serialiseAddress addr
+          prefix = show headId <> "-" <> (T.unpack $ T.takeEnd 8 $ Api.serialiseAddress addr)
           proxyKeysPath = "proxy-keys"
         (vk, sk) <- ExceptT $ runCardanoCli a $ keyGen $ keyGenTemplate proxyKeysPath $ prefix <> ".cardano"
         proxyAddr <- ExceptT $ runCardanoCli a $ buildAddress vk

--- a/hydra-pay/src/HydraPay/Proxy.hs
+++ b/hydra-pay/src/HydraPay/Proxy.hs
@@ -85,9 +85,9 @@ addProxyInfo hid addr pinfo = do
       anyConflict onConflictDoNothing
 
   -- Create the linkages for the new proxy info
-  for_ result $ \pi -> do
+  for_ result $ \pi_ -> do
     runInsertReturningList $ insert (Db.db ^. Db.db_proxyHead) $ insertExpressions
-      [ Db.ProxyHead default_ (val_ $ pk pi) (val_ $ Db.HeadId $ SqlSerial hid)
+      [ Db.ProxyHead default_ (val_ $ pk pi_) (val_ $ Db.HeadId $ SqlSerial hid)
       ]
 
   pure $ headMaybe result >>= dbProxyInfoToProxyInfo

--- a/hydra-pay/src/HydraPay/Proxy.hs
+++ b/hydra-pay/src/HydraPay/Proxy.hs
@@ -42,6 +42,7 @@ getProxyInfo hid addr = do
     proxy <- all_ (Db.db ^. Db.db_proxies)
     ph <- all_ (Db.db ^. Db.db_proxyHead)
     guard_ (h ^. Db.hydraHead_id ==. (val_ $ SqlSerial hid))
+    guard_ (proxy ^. Db.proxy_chainAddress ==. val_ (addr ^. to Api.serialiseAddress))
     guard_ ((ph ^. Db.proxyHead_head) `references_` h)
     guard_ ((ph ^. Db.proxyHead_proxy) `references_` proxy)
     pure proxy

--- a/hydra-pay/src/HydraPay/Worker.hs
+++ b/hydra-pay/src/HydraPay/Worker.hs
@@ -19,14 +19,3 @@ paymentChannelTask = TaskWithoutHasRun
   , _taskWithoutHasRun_checkedOutBy = _paymentChannelTask_checkedOutBy
   , _taskWithoutHasRun_result = WrapColumnar . _paymentChannelTask_status
   }
-
--- openChannelTask :: Task Postgres PaymentChannelTaskT (WrapColumnar PaymentChannelReq) Text (WrapColumnar (Maybe Bool))
--- openChannelTask = Task
---   { _task_filter = \a -> case _paymentChannelTask_payload a of
---       PaymentChannelReq_Init _ -> val_ True
---       _ -> False
---   , _task_payload = WrapColumnar . _paymentChannelTask_payload
---   , _task_checkedOutBy = paymentChannelTask_checkedOutBy
---   , _task_hasRun = paymentChannelTask_finished
---   , _task_result = paymentChannelTask_status . iso WrapColumnar unWrapColumnar
---   }

--- a/hydra-pay/src/HydraPay/Worker.hs
+++ b/hydra-pay/src/HydraPay/Worker.hs
@@ -1,0 +1,27 @@
+-- |
+
+module HydraPay.Worker where
+
+import Control.Lens (iso, makeLenses)
+import Data.Text (Text)
+import Database.Beam
+import Database.Beam.Postgres
+import Database.Beam.Postgres.Syntax (PgExpressionSyntax(..), emit)
+import Database.Beam.Backend.SQL
+import Database.Beam.Backend.SQL.BeamExtensions
+import Rhyolite.DB.Beam.Types (WrapColumnar(..))
+import Rhyolite.Task.Beam
+import Rhyolite.Task.Beam.Worker
+
+import HydraPay.Database
+import HydraPay.Database.Workers
+
+
+openChannelTask :: Task Postgres OpenChannelTaskT (WrapColumnar OpenChannelReq) Text (WrapColumnar (Maybe Bool))
+openChannelTask = Task
+  { _task_filter = const $ val_ True
+  , _task_payload = WrapColumnar . _openChannelTask_payload
+  , _task_checkedOutBy = openChannelTask_checkedOutBy
+  , _task_hasRun = openChannelTask_finished
+  , _task_result = openChannelTask_status . iso WrapColumnar unWrapColumnar
+  }

--- a/hydra-pay/src/HydraPay/Worker.hs
+++ b/hydra-pay/src/HydraPay/Worker.hs
@@ -12,13 +12,13 @@ import Rhyolite.Task.Beam
 import HydraPay.Database.Workers
 
 
-paymentChannelTask :: Task Postgres PaymentChannelTaskT (WrapColumnar PaymentChannelReq) Text (WrapColumnar (Maybe Bool))
-paymentChannelTask = Task
-  { _task_filter = const $ val_ True
-  , _task_payload = WrapColumnar . _paymentChannelTask_payload
-  , _task_checkedOutBy = paymentChannelTask_checkedOutBy
-  , _task_hasRun = paymentChannelTask_finished
-  , _task_result = paymentChannelTask_status . iso WrapColumnar unWrapColumnar
+paymentChannelTask :: TaskWithoutHasRun Postgres PaymentChannelTaskT (WrapColumnar PaymentChannelReq) Text (WrapColumnar (Maybe Bool))
+paymentChannelTask = TaskWithoutHasRun
+  { _taskWithoutHasRun_filter = \chan -> _paymentChannelTask_status chan /=. (val_ $ Just True)
+
+  , _taskWithoutHasRun_payload = WrapColumnar . _paymentChannelTask_payload
+  , _taskWithoutHasRun_checkedOutBy = _paymentChannelTask_checkedOutBy
+  , _taskWithoutHasRun_result = WrapColumnar . _paymentChannelTask_status
   }
 
 -- openChannelTask :: Task Postgres PaymentChannelTaskT (WrapColumnar PaymentChannelReq) Text (WrapColumnar (Maybe Bool))

--- a/hydra-pay/src/HydraPay/Worker.hs
+++ b/hydra-pay/src/HydraPay/Worker.hs
@@ -2,7 +2,6 @@
 
 module HydraPay.Worker where
 
-import Control.Lens (iso)
 import Data.Text (Text)
 import Database.Beam
 import Database.Beam.Postgres

--- a/hydra-pay/src/HydraPay/Worker.hs
+++ b/hydra-pay/src/HydraPay/Worker.hs
@@ -12,11 +12,22 @@ import Rhyolite.Task.Beam
 import HydraPay.Database.Workers
 
 
-openChannelTask :: Task Postgres OpenChannelTaskT (WrapColumnar OpenChannelReq) Text (WrapColumnar (Maybe Bool))
-openChannelTask = Task
+paymentChannelTask :: Task Postgres PaymentChannelTaskT (WrapColumnar PaymentChannelReq) Text (WrapColumnar (Maybe Bool))
+paymentChannelTask = Task
   { _task_filter = const $ val_ True
-  , _task_payload = WrapColumnar . _openChannelTask_payload
-  , _task_checkedOutBy = openChannelTask_checkedOutBy
-  , _task_hasRun = openChannelTask_finished
-  , _task_result = openChannelTask_status . iso WrapColumnar unWrapColumnar
+  , _task_payload = WrapColumnar . _paymentChannelTask_payload
+  , _task_checkedOutBy = paymentChannelTask_checkedOutBy
+  , _task_hasRun = paymentChannelTask_finished
+  , _task_result = paymentChannelTask_status . iso WrapColumnar unWrapColumnar
   }
+
+-- openChannelTask :: Task Postgres PaymentChannelTaskT (WrapColumnar PaymentChannelReq) Text (WrapColumnar (Maybe Bool))
+-- openChannelTask = Task
+--   { _task_filter = \a -> case _paymentChannelTask_payload a of
+--       PaymentChannelReq_Init _ -> val_ True
+--       _ -> False
+--   , _task_payload = WrapColumnar . _paymentChannelTask_payload
+--   , _task_checkedOutBy = paymentChannelTask_checkedOutBy
+--   , _task_hasRun = paymentChannelTask_finished
+--   , _task_result = paymentChannelTask_status . iso WrapColumnar unWrapColumnar
+--   }

--- a/hydra-pay/src/HydraPay/Worker.hs
+++ b/hydra-pay/src/HydraPay/Worker.hs
@@ -2,18 +2,13 @@
 
 module HydraPay.Worker where
 
-import Control.Lens (iso, makeLenses)
+import Control.Lens (iso)
 import Data.Text (Text)
 import Database.Beam
 import Database.Beam.Postgres
-import Database.Beam.Postgres.Syntax (PgExpressionSyntax(..), emit)
-import Database.Beam.Backend.SQL
-import Database.Beam.Backend.SQL.BeamExtensions
 import Rhyolite.DB.Beam.Types (WrapColumnar(..))
 import Rhyolite.Task.Beam
-import Rhyolite.Task.Beam.Worker
 
-import HydraPay.Database
 import HydraPay.Database.Workers
 
 


### PR DESCRIPTION
A single proxy per user was found to be insufficient, and could lead to double spending of fuel amongst the nodes in an environment with many heads.

This change forces a proxy per node, so that each node has its own funds to fuel and commit that aren't in contention even when many heads with shared participants are present.