### PR TITLE
Remove 'shouldClose' from PaymentChannels

### DIFF
--- a/hydra-pay/src/HydraPay/Database.hs
+++ b/hydra-pay/src/HydraPay/Database.hs
@@ -112,7 +112,6 @@ data PaymentChannelsT f = PaymentChannel
   , _paymentChannel_expiry :: C f UTCTime
   , _paymentChannel_status :: C f PaymentChannelStatus
   , _paymentChannel_commits :: C f Int32
-  , _paymentChannel_shouldClose :: C f Bool
   }
   deriving (Generic)
 

--- a/hydra-pay/src/HydraPay/PaymentChannel/Postgres.hs
+++ b/hydra-pay/src/HydraPay/PaymentChannel/Postgres.hs
@@ -285,7 +285,6 @@ createPaymentChannel a (PaymentChannelConfig name first second amount chain) = d
                           (addOneDayInterval_ current_timestamp_)
                           (val_ PaymentChannelStatus_Submitting)
                           (val_ 0)
-                          (val_ False)
                         ]
     pure newHead
   pure $ primaryKey dbHead


### PR DESCRIPTION
This is now unnecessary.